### PR TITLE
Feature/queue item redirection

### DIFF
--- a/app/controllers/v1/queue_items_controller.rb
+++ b/app/controllers/v1/queue_items_controller.rb
@@ -2,7 +2,7 @@ module V1
   class QueueItemsController < ApplicationController
     # GET /v1/queue
     def index
-      @queue_items = policy_scope(QueueItem)
+      @queue_items = policy_scope(QueueItem).where(bag: nil)
     end
 
     # GET /v1/queue/:id

--- a/app/controllers/v1/queue_items_controller.rb
+++ b/app/controllers/v1/queue_items_controller.rb
@@ -9,6 +9,11 @@ module V1
     def show
       @queue_item = QueueItem.find(params[:id])
       authorize @queue_item
+      if @queue_item.bag
+        head 303, location: v1_bag_url(@queue_item.bag)
+      else
+        render template: "v1/queue_items/show", status: 200
+      end
     end
 
     # POST /v1/requests/:bag_id/complete

--- a/spec/controllers/v1/queue_items_controller_spec.rb
+++ b/spec/controllers/v1/queue_items_controller_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe V1::QueueItemsController, type: :controller do
 
     describe "GET #index" do
       it_behaves_like "an index endpoint" do
+        before(:each) do
+          # We invoke the done_proc here to add an additional,
+          # non-pending (complete) queue item.  Its existence
+          # will cause the tests to fail if it is retrieved by
+          # the index endpoint.
+          # This is a hack.
+          done_proc.call(user)
+        end
         let(:key) { :id }
         let(:factory) { pending_proc }
         let(:assignee) { :queue_items }

--- a/spec/controllers/v1/queue_items_controller_spec.rb
+++ b/spec/controllers/v1/queue_items_controller_spec.rb
@@ -3,28 +3,115 @@ require 'rails_helper'
 RSpec.describe V1::QueueItemsController, type: :controller do
   describe "/v1" do
 
-    factory_proc = proc do |user|
+    pending_proc = proc do |user|
       if user
-        Fabricate(:queue_item, request: Fabricate(:request, user: user))
+        Fabricate(:queue_item,
+          bag: nil,
+          request: Fabricate(:request, user: user))
       else
-        Fabricate(:queue_item)
+        Fabricate(:queue_item, bag: nil)
+      end
+    end
+
+    done_proc = proc do |user|
+      uuid = SecureRandom.uuid
+      if user
+        Fabricate(:queue_item,
+          bag: Fabricate(:bag, bag_id: uuid, user: user),
+          request: Fabricate(:request, bag_id: uuid, user: user)
+        )
+      else
+        Fabricate(:queue_item,
+          bag: Fabricate(:bag, bag_id: uuid),
+          request: Fabricate(:request, bag_id: uuid)
+        )
       end
     end
 
     describe "GET #index" do
       it_behaves_like "an index endpoint" do
         let(:key) { :id }
-        let(:factory) { factory_proc }
+        let(:factory) { pending_proc }
         let(:assignee) { :queue_items }
       end
     end
 
     describe "GET #show" do
-      it_behaves_like "a show endpoint" do
-        let(:key) { :id }
-        let(:factory) { factory_proc }
-        let(:assignee) { :queue_item }
+      context "queue_item has no bag (is incomplete)" do
+        it_behaves_like "a show endpoint" do
+          let(:key) { :id }
+          let(:factory) { pending_proc }
+          let(:assignee) { :queue_item }
+        end
       end
+      context "queue_item has a bag (is complete)" do
+        before(:each) do
+          request.headers.merge! auth_header
+          get :show, params: {id: record.id}
+        end
+        context "as unauthenticated user" do
+          include_context "as unauthenticated user"
+          let(:record) { done_proc.call }
+          it "returns 401" do
+            expect(response).to have_http_status(401)
+          end
+          it "renders nothing" do
+            expect(response).to render_template(nil)
+          end
+        end
+        context "as underprivileged user" do
+          include_context "as underprivileged user"
+          context "the record belongs to the user" do
+            let(:record) { done_proc.call(user) }
+            it "returns 303" do
+              expect(response).to have_http_status(303)
+            end
+            it "correctly sets the location header" do
+              expect(response.location).to eql(v1_bag_url(record.bag))
+            end
+            it "renders nothing" do
+              expect(response).to render_template(nil)
+            end
+          end
+          context "the record does not belong to the user" do
+            let(:record) { done_proc.call }
+            it "returns 403" do
+              expect(response).to have_http_status(403)
+            end
+            it "renders nothing" do
+              expect(response).to render_template(nil)
+            end
+          end
+        end
+        context "as admin" do
+          include_context "as admin user"
+          context "the record belongs to the user" do
+            let(:record) { done_proc.call(user) }
+            it "returns 303" do
+              expect(response).to have_http_status(303)
+            end
+            it "correctly sets the location header" do
+              expect(response.location).to eql(v1_bag_url(record.bag))
+            end
+            it "renders nothing" do
+              expect(response).to render_template(nil)
+            end
+          end
+          context "the record does not belong to the user" do
+            let(:record) { done_proc.call }
+            it "returns 303" do
+              expect(response).to have_http_status(303)
+            end
+            it "correctly sets the location header" do
+              expect(response.location).to eql(v1_bag_url(record.bag))
+            end
+            it "renders nothing" do
+              expect(response).to render_template(nil)
+            end
+          end
+        end
+      end
+
     end
 
     describe "POST #create" do


### PR DESCRIPTION
This adds some missing functionality specified by the API reference and the confluence chipmunk doc. The production code is reasonably clean, the tests less so. Refactoring the ill-fitting shared examples is out of scope for this sprint, I feel.