### PR TITLE
requests: upload link, specs, etc

### DIFF
--- a/app/controllers/v1/requests_controller.rb
+++ b/app/controllers/v1/requests_controller.rb
@@ -19,7 +19,7 @@ module V1
       if existing_record
         head 303, location: v1_request_url(existing_record)
       else
-        @request_record = RequestBuilder.new(create_params).build
+        @request_record = RequestBuilder.new.create(create_params.merge({user: current_user}))
         if @request_record.errors.empty?
           head 201, location: v1_request_url(@request_record)
         else
@@ -31,7 +31,7 @@ module V1
     private
 
     def create_params
-      request.parameters[:request] # This bypasses strong parameters
+      params.require(:request).permit([:bag_id, :external_id, :content_type])
     end
 
   end

--- a/app/models/bag.rb
+++ b/app/models/bag.rb
@@ -3,7 +3,7 @@ class Bag < ApplicationRecord
   belongs_to :user
 
   def to_param
-    :bag_id
+    bag_id
   end
 
   validates :bag_id, presence: true

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -4,7 +4,7 @@ class Request < ApplicationRecord
   has_one :queue_item
 
   def to_param
-    :bag_id
+    bag_id
   end
 
   validates :bag_id, presence: true

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -9,11 +9,18 @@ class Request < ApplicationRecord
 
   validates :bag_id, presence: true
   validates :user_id, presence: true
-  validates :upload_link, presence: true
   validates :external_id, presence: true
 
   def self.policy_class
     RequestPolicy
+  end
+
+  def upload_path
+    File.join(Rails.application.config.upload['upload_path'],user.username,bag_id)
+  end
+
+  def upload_link
+    File.join(Rails.application.config.upload['rsync_point'],bag_id)
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   validates :email, presence: true
   validates :admin, inclusion: { in: [true, false] }
   validates :api_key, presence: true
+  validates :username, presence: true
 
   # Assign an API key
   before_create do |user|

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,5 +38,7 @@ module Chipmunk
     config.api_only = true
 
     config.autoload_paths << Rails.root.join('lib')
+
+    config.upload = config_for('upload')
   end
 end

--- a/config/upload.yml
+++ b/config/upload.yml
@@ -1,0 +1,11 @@
+# configuration for upload paths
+
+production:
+
+development:
+
+test:
+  # application-writable directory where upload points should be created, e.g. /pfdr/incoming/uniqname
+  upload_path: /pfdr/incoming/
+  # rsync point to user-writable upload path
+  rsync_point: localhost:incoming

--- a/db/migrate/20170530181632_add_username_to_users.rb
+++ b/db/migrate/20170530181632_add_username_to_users.rb
@@ -1,0 +1,6 @@
+class AddUsernameToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :username, :string, null: false
+    add_index :users, :username, unique: true
+  end
+end

--- a/db/migrate/20170531155509_add_unique_constraints_to_requests.rb
+++ b/db/migrate/20170531155509_add_unique_constraints_to_requests.rb
@@ -1,0 +1,5 @@
+class AddUniqueConstraintsToRequests < ActiveRecord::Migration[5.1]
+  def change
+    add_index :requests, :external_id, unique: true
+  end
+end

--- a/db/migrate/20170531160317_remove_upload_link_from_requests.rb
+++ b/db/migrate/20170531160317_remove_upload_link_from_requests.rb
@@ -1,0 +1,5 @@
+class RemoveUploadLinkFromRequests < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :requests, :upload_link
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170510191941) do
+ActiveRecord::Schema.define(version: 20170530181632) do
 
   create_table "bags", force: :cascade do |t|
     t.string "bag_id", null: false
@@ -50,6 +50,8 @@ ActiveRecord::Schema.define(version: 20170510191941) do
     t.string "api_key", default: "x", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username", null: false
+    t.index ["username"], name: "index_users_on_username", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170530181632) do
+ActiveRecord::Schema.define(version: 20170531160317) do
 
   create_table "bags", force: :cascade do |t|
     t.string "bag_id", null: false
@@ -37,10 +37,10 @@ ActiveRecord::Schema.define(version: 20170530181632) do
     t.string "type", null: false
     t.integer "user_id", null: false
     t.string "external_id", null: false
-    t.string "upload_link", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["bag_id"], name: "index_requests_on_bag_id", unique: true
+    t.index ["external_id"], name: "index_requests_on_external_id", unique: true
     t.index ["user_id"], name: "index_requests_on_user_id"
   end
 
@@ -51,8 +51,8 @@ ActiveRecord::Schema.define(version: 20170530181632) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "username", null: false
-    t.index ["username"], name: "index_users_on_username", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
 end

--- a/lib/request_builder.rb
+++ b/lib/request_builder.rb
@@ -9,15 +9,31 @@
 #
 # This process is synchronous.
 class RequestBuilder
-
-  def initialize(args)
-
+  def initialize
   end
 
-  # Returns the request.
-  # Controller currently assumes this saves it.
-  def build
-
+  # Returns the request. Pass a hash with all the parameters necessary for
+  # creation of the particular sub-request as well as the 'content_type' key to
+  # control which type of request gets generated (currently, 'audio' or
+  # 'digital'). Just using a hash rather than keyword parameters since Rails
+  # parameters and keyword args still don't mix well.
+  def create(params)
+    klass_for(params.delete(:content_type))
+      .create(params)
   end
 
+  def klass_for(content_type)
+    case content_type
+    when "audio"
+      AudioRequest
+    when "digital"
+      DigitalRequest
+    else
+      raise ArgumentError, "Unknown content type #{content_type} for request"
+    end
+  end
+
+  private
+
+  attr_accessor :params
 end

--- a/spec/controllers/v1/requests_controller_spec.rb
+++ b/spec/controllers/v1/requests_controller_spec.rb
@@ -28,16 +28,15 @@ RSpec.describe V1::RequestsController, type: :controller do
         {
           bag_id: SecureRandom.uuid,
           content_type: "audio",
-          user: user.email,
-          mirlyn_id: SecureRandom.uuid
-        }
+          external_id: SecureRandom.uuid
+        }.with_indifferent_access
       end
       let(:request_builder) { double(:request_builder, build: nil) }
       let(:expected_record) do
         Fabricate(:audio_request,
           bag_id: attributes[:bag_id],
           user: user,
-          external_id: attributes[:mirlyn_id]
+          external_id: attributes[:external_id]
         )
       end
       before(:each) do
@@ -70,11 +69,11 @@ RSpec.describe V1::RequestsController, type: :controller do
           end
           context "RequestBuilder returns a valid record" do
             before(:each) do
-              allow(request_builder).to receive(:build).and_return(expected_record)
+              allow(request_builder).to receive(:create).and_return(expected_record)
             end
             it "passes the parameters to a RequestBuilder" do
               post :create, params: {request: attributes}
-              expect(RequestBuilder).to have_received(:new).with(attributes)
+              expect(request_builder).to have_received(:create).with(attributes.merge({user: user}))
             end
             it "returns 201" do
               post :create, params: {request: attributes}
@@ -93,7 +92,7 @@ RSpec.describe V1::RequestsController, type: :controller do
             before(:each) do
               record = Fabricate.build(:request, user: nil)
               record.valid?
-              allow(request_builder).to receive(:build).and_return(record)
+              allow(request_builder).to receive(:create).and_return(record)
             end
             it "returns 422" do
               post :create, params: {request: attributes}

--- a/spec/fabricators/request_fabricator.rb
+++ b/spec/fabricators/request_fabricator.rb
@@ -3,7 +3,6 @@ Fabricator(:base_request, class_name: "Request") do
   bag_id { SecureRandom.uuid }
   user { Fabricate(:user) }
   external_id { SecureRandom.uuid }
-  upload_link { Faker::Internet.email }
 end
 
 Fabricator(:audio_request, from: :base_request) do

--- a/spec/fabricators/user_fabricator.rb
+++ b/spec/fabricators/user_fabricator.rb
@@ -1,5 +1,6 @@
 Fabricator(:user) do
   email { Faker::Internet.email }
+  username { Faker::Internet.user_name }
   admin false
   api_key { SecureRandom.uuid }
 end

--- a/spec/models/audio_bag_spec.rb
+++ b/spec/models/audio_bag_spec.rb
@@ -1,13 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe AudioBag, type: :model do
-  [:bag_id, :user_id, :external_id, :storage_location].each do |field|
-    it "#{field} is required" do
-      expect(Fabricate.build(:audio_bag, field => nil)).to_not be_valid
-    end
-  end
-
-  it "#content_type is :audio" do
-    expect(Fabricate.build(:audio_bag).content_type).to eql(:audio)
-  end
+  it_behaves_like "a bag", :audio_bag, :audio
 end

--- a/spec/models/audio_request_spec.rb
+++ b/spec/models/audio_request_spec.rb
@@ -1,11 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe AudioRequest, type: :model do
-  [:bag_id, :user_id, :external_id, :upload_link].each do |field|
-    it "#{field} is required" do
-      expect(Fabricate.build(:audio_request, field => nil)).to_not be_valid
-    end
-  end
+
+  it_behaves_like "a request", :audio_request
+
 
   it "#content_type is :audio" do
     expect(Fabricate.build(:audio_request).content_type).to eql(:audio)

--- a/spec/models/digital_bag_spec.rb
+++ b/spec/models/digital_bag_spec.rb
@@ -1,13 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe DigitalBag, type: :model do
-  [:bag_id, :user_id, :external_id, :storage_location].each do |field|
-    it "#{field} is required" do
-      expect(Fabricate.build(:digital_bag, field => nil)).to_not be_valid
-    end
-  end
-
-  it "#content_type is :digital" do
-    expect(Fabricate.build(:digital_bag).content_type).to eql(:digital)
-  end
+  it_behaves_like "a bag", :digital_bag, :digital
 end

--- a/spec/models/digital_request_spec.rb
+++ b/spec/models/digital_request_spec.rb
@@ -1,11 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe DigitalRequest, type: :model do
-  [:bag_id, :user_id, :external_id, :upload_link].each do |field|
-    it "#{field} is required" do
-      expect(Fabricate.build(:digital_request, field => nil)).to_not be_valid
-    end
-  end
+
+  it_behaves_like "a request", :digital_request
 
   it "#content_type is :digital" do
     expect(Fabricate.build(:digital_request).content_type).to eql(:digital)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,14 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  [:email, :admin, :api_key].each do |field|
+
+  def minimal_user
+    User.new(email: Faker::Internet.email,
+             username: Faker::Internet.user_name)
+  end
+
+  [:email, :admin, :api_key, :username].each do |field|
     it "#{field} is required" do
       expect(Fabricate.build(:user, field => nil)).to_not be_valid
     end
   end
 
   describe "#email" do
-    it "must be unqiue" do
+    it "must be unique" do
       expect {
         Fabricate(:user, email: "test@example.com")
         Fabricate(:user, email: "test@example.com")
@@ -16,18 +22,30 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "#username" do
+    it "must be unique" do
+      expect {
+        Fabricate(:user, username: "test")
+        Fabricate(:user, username: "test")
+      }.to raise_error ActiveRecord::RecordNotUnique
+    end
+  end
+
+    let(:user)  {  }
+
   describe "#admin" do
     it "defaults to false" do
-      expect(User.new(email: Faker::Internet.email).admin).to be false
+      expect(minimal_user.admin).to be false
     end
   end
 
   describe "#api_key" do
     it "generates an api_key by default" do
-      expect(User.new(email: Faker::Internet.email).api_key).to_not be_nil
+      expect(minimal_user.api_key).to_not be_nil
     end
     it "a user can be found by api_key" do
-      user = User.create(email: Faker::Internet.email)
+      user = User.create(email: Faker::Internet.email,
+                         username: Faker::Internet.user_name)
       expect(User.find_by_api_key(user.api_key)).to eql(user)
     end
   end

--- a/spec/request_builder_spec.rb
+++ b/spec/request_builder_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe RequestBuilder do
+
+  let(:config_rsync_point) { Rails.application.config.upload['rsync_point'] }
+  let(:config_upload_path) { Rails.application.config.upload['upload_path'] }
+  let(:user) { Fabricate(:user) }
+
+  describe '#build' do
+    subject { described_class.new.create(params) }
+
+    context "when given audio params" do
+      let(:params) { {content_type: 'audio',
+                      user: user,
+                      bag_id: 1} }
+
+      it { is_expected.to be_an_instance_of(AudioRequest)}
+
+      context "with user parameters" do
+        it "returns a Request with the configured upload link" do
+          expect(subject.upload_link).to match(/^#{config_rsync_point}/)
+        end
+      end
+    end
+
+    context "when given digital forensics params" do
+      let(:params) { {content_type: 'digital' }}
+
+      it { is_expected.to be_an_instance_of(DigitalRequest) }
+    end
+
+    context "when building two different requests" do
+      let (:params1) { {content_type: 'audio', bag_id: '1', 
+                        external_id: 'foo', user: user} }
+      let (:request1) { described_class.new().create(params1) }
+
+      let (:params2) { {content_type: 'audio', bag_id: '2', 
+                        external_id: 'bar', user: user } }
+      let (:request2) { described_class.new().create(params2) }
+
+      it "returns a different upload link" do
+        expect(request1.upload_link).not_to eq(request2.upload_link)
+      end
+      
+    end
+  end
+end
+

--- a/spec/support/examples/a_bag.rb
+++ b/spec/support/examples/a_bag.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.shared_examples "a bag" do |factory_id,content_type|
+  [:bag_id, :user_id, :external_id, :storage_location].each do |field|
+    it "#{field} is required" do
+      expect(Fabricate.build(factory_id, field => nil)).to_not be_valid
+    end
+  end
+
+  it "#content_type is #{content_type}" do
+    expect(Fabricate.build(factory_id).content_type).to eql(content_type)
+  end
+
+  describe "#to_param" do
+    it "uses the bag id" do
+      bag_id = 'made_up'
+      expect(Fabricate.build(factory_id, bag_id: bag_id).to_param).to eq(bag_id)
+    end
+  end
+
+end
+

--- a/spec/support/examples/a_request.rb
+++ b/spec/support/examples/a_request.rb
@@ -32,5 +32,12 @@ RSpec.shared_examples "a request" do |factory_id|
     expect(request.upload_link).to eq(File.join(upload_link,'1'))
   end
 
+  describe "#to_param" do
+    it "uses the bag id" do
+      bag_id = 'made_up'
+      expect(Fabricate.build(factory_id, bag_id: bag_id).to_param).to eq(bag_id)
+    end
+  end
+
 end
 

--- a/spec/support/examples/a_request.rb
+++ b/spec/support/examples/a_request.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.shared_examples "a request" do |factory_id|
+  let(:upload_path) { Rails.application.config.upload['upload_path'] }
+  let(:upload_link) { Rails.application.config.upload['rsync_point'] }
+
+  [:bag_id, :user_id, :external_id].each do |field|
+    it "#{field} is required" do
+      expect(Fabricate.build(factory_id, field => nil)).to_not be_valid
+    end
+  end
+
+  %w(bag_id external_id).each do |field|
+    describe "#{field}" do
+      it "must be unique" do
+        expect {
+          2.times { Fabricate(factory_id, field.to_sym => "test") }
+        }.to raise_error ActiveRecord::RecordNotUnique
+      end
+    end
+  end
+
+  it "has an upload path based on the user and the bag id" do
+    user = Fabricate.build(:user, username: 'someuser')
+    request = Fabricate.build(factory_id, user: user, bag_id: 1)
+    expect(request.upload_path).to eq(File.join(upload_path,'someuser','1'))
+  end
+
+  it "has an upload link based on the rsync point and bag id" do
+    user = Fabricate.build(:user, username: 'someuser')
+    request = Fabricate.build(factory_id, user: user, bag_id: 1)
+    expect(request.upload_link).to eq(File.join(upload_link,'1'))
+  end
+
+end
+


### PR DESCRIPTION
Requests - upload path, link, specs
- Adds username to user - required for constructing the upload path.
- Uses strong parameters in requestcontroller
- Gets user from current_user
- Consistently uses "external_id" instead of "mirlyn_id"
- Uses 'create' instead of 'build' and passes parameters to create instead
of new. This more closely matches the convention for a factory
that saves the thing it makes.
- Continues to just pass the request parameters through the factory to
the object initializer. I tried some things with keyword args, but the
way Rails handles parameters vs. the Ruby keyword args makes it messy to
marshal/unmarshal things that just end up getting passed through to the
object constructor anyway.