### PR TITLE
fix url generation for bags & requests

### DIFF
--- a/app/models/bag.rb
+++ b/app/models/bag.rb
@@ -3,7 +3,7 @@ class Bag < ApplicationRecord
   belongs_to :user
 
   def to_param
-    :bag_id
+    bag_id
   end
 
   validates :bag_id, presence: true

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -4,7 +4,7 @@ class Request < ApplicationRecord
   has_one :queue_item
 
   def to_param
-    :bag_id
+    bag_id
   end
 
   validates :bag_id, presence: true

--- a/spec/models/audio_bag_spec.rb
+++ b/spec/models/audio_bag_spec.rb
@@ -1,13 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe AudioBag, type: :model do
-  [:bag_id, :user_id, :external_id, :storage_location].each do |field|
-    it "#{field} is required" do
-      expect(Fabricate.build(:audio_bag, field => nil)).to_not be_valid
-    end
-  end
-
-  it "#content_type is :audio" do
-    expect(Fabricate.build(:audio_bag).content_type).to eql(:audio)
-  end
+  it_behaves_like "a bag", :audio_bag, :audio
 end

--- a/spec/models/digital_bag_spec.rb
+++ b/spec/models/digital_bag_spec.rb
@@ -1,13 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe DigitalBag, type: :model do
-  [:bag_id, :user_id, :external_id, :storage_location].each do |field|
-    it "#{field} is required" do
-      expect(Fabricate.build(:digital_bag, field => nil)).to_not be_valid
-    end
-  end
-
-  it "#content_type is :digital" do
-    expect(Fabricate.build(:digital_bag).content_type).to eql(:digital)
-  end
+  it_behaves_like "a bag", :digital_bag, :digital
 end

--- a/spec/support/examples/a_bag.rb
+++ b/spec/support/examples/a_bag.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.shared_examples "a bag" do |factory_id,content_type|
+  [:bag_id, :user_id, :external_id, :storage_location].each do |field|
+    it "#{field} is required" do
+      expect(Fabricate.build(factory_id, field => nil)).to_not be_valid
+    end
+  end
+
+  it "#content_type is #{content_type}" do
+    expect(Fabricate.build(factory_id).content_type).to eql(content_type)
+  end
+
+  describe "#to_param" do
+    it "uses the bag id" do
+      bag_id = 'made_up'
+      expect(Fabricate.build(factory_id, bag_id: bag_id).to_param).to eq(bag_id)
+    end
+  end
+
+end
+

--- a/spec/support/examples/a_request.rb
+++ b/spec/support/examples/a_request.rb
@@ -32,5 +32,12 @@ RSpec.shared_examples "a request" do |factory_id|
     expect(request.upload_link).to eq(File.join(upload_link,'1'))
   end
 
+  describe "#to_param" do
+    it "uses the bag id" do
+      bag_id = 'made_up'
+      expect(Fabricate.build(factory_id, bag_id: bag_id).to_param).to eq(bag_id)
+    end
+  end
+
 end
 


### PR DESCRIPTION
Was returning :bag_id but should have returned bag_id. The existing
tests didn't catch this issue because both the tests and the code used
e.g. v1_request_url to check the returned URLs.