### PR TITLE
Render external_id as simply 'external_id'

### DIFF
--- a/app/views/v1/bags/_bag.json.jbuilder
+++ b/app/views/v1/bags/_bag.json.jbuilder
@@ -1,7 +1,7 @@
 json.bag_id bag.bag_id
 json.user bag.user.email
 json.content_type bag.content_type
-json.set! "#{bag.external_service}_id".to_sym, bag.external_id
+json.external_id bag.external_id
 if @current_user&.admin?
   json.storage_location bag.storage_location
 end

--- a/spec/views/v1/bags/index.json.jbuilder_spec.rb
+++ b/spec/views/v1/bags/index.json.jbuilder_spec.rb
@@ -17,7 +17,7 @@ describe "/v1/bags/index.json.jbuilder" do
     {
       bag_id: bag.bag_id,
       user: bag.user.email,
-      mirlyn_id: bag.external_id,
+      external_id: bag.external_id,
       content_type: bag.content_type,
       created_at: bag.created_at.to_formatted_s(:default),
       updated_at: bag.updated_at.to_formatted_s(:default)

--- a/spec/views/v1/bags/show.json.jbuilder_spec.rb
+++ b/spec/views/v1/bags/show.json.jbuilder_spec.rb
@@ -17,7 +17,7 @@ describe "/v1/bags/show.json.jbuilder" do
     {
       bag_id: bag.bag_id,
       user: bag.user.email,
-      mirlyn_id: bag.external_id,
+      external_id: bag.external_id,
       content_type: bag.content_type,
       created_at: bag.created_at.to_formatted_s(:default),
       updated_at: bag.updated_at.to_formatted_s(:default)


### PR DESCRIPTION
Previously we tried to get the external_service name from
the bag model. This changes the views to simply render
the field as 'external_id'.

We're not using this now, no need to try to keep the machinery around.