### PR TITLE
Bag knows its own storage paths

### DIFF
--- a/app/jobs/bag_move_job.rb
+++ b/app/jobs/bag_move_job.rb
@@ -1,10 +1,10 @@
 require 'open3'
 
 class BagMoveJob < ApplicationJob
-  def perform(queue_item, src_path, dest_path)
+  def perform(queue_item)
     @queue_item = queue_item
-    @src_path = src_path
-    @dest_path = dest_path
+    @src_path = queue_item.bag.src_path
+    @dest_path = queue_item.bag.dest_path
     @errors = []
 
     begin
@@ -34,6 +34,7 @@ class BagMoveJob < ApplicationJob
   attr_accessor :queue_item, :src_path, :dest_path
 
   def bag_is_valid?
+    return false unless File.exists?(src_path)
     bag = ChipmunkBag.new(src_path)
     if bag.valid?
       true

--- a/app/models/bag.rb
+++ b/app/models/bag.rb
@@ -16,8 +16,12 @@ class Bag < ApplicationRecord
     BagPolicy
   end
 
-  def upload_path
+  def src_path
     File.join(Rails.application.config.upload['upload_path'],user.username,bag_id)
+  end
+  
+  def dest_path
+    File.join(Rails.application.config.upload['storage_path'],bag_id)
   end
 
   def upload_link
@@ -25,7 +29,7 @@ class Bag < ApplicationRecord
   end
 
   def external_validation_cmd
-    [Rails.application.config.validation[content_type.to_s],upload_path].join(" ")
+    [Rails.application.config.validation[content_type.to_s],src_path].join(" ")
   end
 
 end

--- a/config/validation.yml
+++ b/config/validation.yml
@@ -5,7 +5,9 @@ production:
 development:
   audio: "/path/to/validator"
   digital: "/path/to/validator"
+  video: "/path/to/validator"
 
 test:
   audio: "/path/to/validator"
   digital: "/path/to/validator"
+  video: "/path/to/validator"

--- a/lib/queue_item_builder.rb
+++ b/lib/queue_item_builder.rb
@@ -13,7 +13,7 @@ class QueueItemBuilder
     queue_item = QueueItem.new(bag: request)
     if queue_item.valid?
       queue_item.save!
-      BagMoveJob.perform_later(queue_item, request.upload_path, storage_location(request))
+      BagMoveJob.perform_later(queue_item)
       return :created, queue_item
     else
       return :invalid, queue_item
@@ -22,9 +22,4 @@ class QueueItemBuilder
 
   private
 
-  # should get moved to a merged request/bag
-  def storage_location(request)
-    root = Rails.application.config.upload['storage_path']
-    File.join root, request.bag_id
-  end
 end

--- a/spec/models/bag_spec.rb
+++ b/spec/models/bag_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Bag, type: :model do
 
   let(:upload_path) { Rails.application.config.upload['upload_path'] }
   let(:upload_link) { Rails.application.config.upload['rsync_point'] }
+  let(:storage_path) { Rails.application.config.upload['storage_path'] }
 
   [:bag_id, :user_id, :external_id, :storage_location, :content_type].each do |field|
     it "#{field} is required" do
@@ -19,10 +20,16 @@ RSpec.describe Bag, type: :model do
     end
   end
 
-  it "has an upload path based on the user and the bag id" do
+  it "has an source path based on the user and the bag id" do
     user = Fabricate.build(:user, username: 'someuser')
     request = Fabricate.build(:bag, user: user, bag_id: 1)
-    expect(request.upload_path).to eq(File.join(upload_path,'someuser','1'))
+    expect(request.src_path).to eq(File.join(upload_path,'someuser','1'))
+  end
+
+  it "has a destination path based on the storage path and bag id" do
+    user = Fabricate.build(:user, username: 'someuser')
+    request = Fabricate.build(:bag, user: user, bag_id: 1)
+    expect(request.dest_path).to eq(File.join(storage_path,'1'))
   end
 
   it "has an upload link based on the rsync point and bag id" do

--- a/spec/queue_item_builder_spec.rb
+++ b/spec/queue_item_builder_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe QueueItemBuilder do
       upload_path = File.join(config_upload_path, request.user.username, request.bag_id)
       storage_path = File.join(config_storage_path, request.bag_id)
       _, queue_item = subject
-      expect(BagMoveJob).to have_received(:perform_later).with(queue_item, upload_path, storage_path)
+      expect(BagMoveJob).to have_received(:perform_later).with(queue_item)
     end
   end
 


### PR DESCRIPTION
In BagMoveJob, get the bag's source (upload) path and destination
(storage) path directly from the bag rather than passing as
parameters to BagMoveJob.

Also, consistently name these things "src_path" and "dest_paths" in
models, jobs, and tests. "upload path" and "storage path" should refer
to the base directories in the config only. Bag#storage_location should
refer to where an ingested bag actually is, not where it should go.

An alternative to this would be to instead continue passing the source &
destination paths to the BagMoveJob and instead have the validation
command use the source path from the BagMoveJob. That would imply bags
shouldn't know what their upload & storage paths are which seems counter
ot the intention of merging Bag and Request.