### PR TITLE
resque setup; successful dev mode full stack testing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,6 @@
 
 require_relative 'config/application'
 
+task 'resque:setup' => :environment
+
 Rails.application.load_tasks

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,0 +1,1 @@
+Resque.redis.namespace = "chipmunk:#{ENV['RAILS_ENV']}"

--- a/spec/support/fixtures/audio/upload/good/chipmunk-info.txt
+++ b/spec/support/fixtures/audio/upload/good/chipmunk-info.txt
@@ -1,4 +1,4 @@
-External-Identifier: 39015083868474
+External-Identifier: 39015087086396
 Chipmunk-Content-Type: audio
 Bag-ID: b2a07afc-800f-41c6-942d-91989aeed950
 Metadata-URL: http://mirlyn.lib.umich.edu/Record/011500592.xml

--- a/spec/support/fixtures/audio/upload/good/tagmanifest-md5.txt
+++ b/spec/support/fixtures/audio/upload/good/tagmanifest-md5.txt
@@ -1,6 +1,6 @@
 febf1c802920687a4e02fe1e62a2380d  bag-info.txt
 9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt
-7a642073f77969e0aa73b3a1e6816fe3  chipmunk-info.txt
 224d69b3b78b248ad75dbf3e3f7778e7  manifest-md5.txt
 9ec70242a2ea2204af2eeed115b2a0a5  manifest-sha1.txt
 888f366f50152a4d64b89d4ee2d08258  marc.xml
+d987bc5c86cc1a44a978f36984061065  chipmunk-info.txt

--- a/spec/support/fixtures/audio/upload/good/tagmanifest-sha1.txt
+++ b/spec/support/fixtures/audio/upload/good/tagmanifest-sha1.txt
@@ -1,6 +1,6 @@
 a3ca2b17a6c60dfc10baa8c46f2cfab902a49f7e  bag-info.txt
 e2924b081506bac23f5fffe650ad1848a1c8ac1d  bagit.txt
-1275b5aaf5de57f173fa214c76d517055243539a  chipmunk-info.txt
 fe1f4c470f9e6d3dc843a3eed3ddc45dc26fccfb  manifest-md5.txt
 9a10645172c6de8882738bf3a29a90c65c2f3d4f  manifest-sha1.txt
 ba9515177ee749aa7417505ef8bf194f71238ce2  marc.xml
+75d624eca8e0234d0292250b85a9cd25e5b75d80  chipmunk-info.txt


### PR DESCRIPTION
Set up resque to use the correct namespace when enqueuing jobs.

Correct external identifier in bag fixture