### PR TITLE
PFDR-80: don't provide an upload link if there is a storage location

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,15 @@
+SimpleCov.configure do
+  add_filter '/.binstubs'
+  add_filter '/.bundle/'
+  add_filter '/.git/'
+  add_filter '/spec/'
+  add_filter '/test/'
+end
+
+# It's recommended that you delete the if statement based on the type
+# of project you have.
+if ENV["RAILS_ENV"]
+  SimpleCov.start "rails"
+else
+  SimpleCov.start
+end

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ group :test do
   gem 'rspec-activejob'
   gem 'timecop'
   gem 'turnip'
+  gem 'simplecov'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     arel (8.0.0)
     bagit (0.4.0)
       docopt (~> 0.5.0)
@@ -47,7 +49,10 @@ GEM
     byebug (9.0.6)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
+    docile (1.1.5)
     docopt (0.5.0)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
@@ -58,12 +63,14 @@ GEM
     gherkin (4.1.3)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
+    hashdiff (0.3.7)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.8.4)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    json (2.1.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
@@ -88,6 +95,7 @@ GEM
     pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
+    public_suffix (3.0.1)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     rack (2.0.3)
@@ -164,6 +172,12 @@ GEM
       rspec-mocks (~> 3.6.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
+    safe_yaml (1.0.4)
+    simplecov (0.15.1)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     sinatra (2.0.0)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -193,6 +207,10 @@ GEM
     validatable (1.6.7)
     vegas (0.1.11)
       rack (>= 1.0.0)
+    webmock (3.1.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -219,9 +237,11 @@ DEPENDENCIES
   rspec
   rspec-activejob
   rspec-rails
+  simplecov
   sqlite3
   timecop
   turnip
+  webmock
 
 BUNDLED WITH
-   1.14.6
+   1.15.4

--- a/app/models/bag.rb
+++ b/app/models/bag.rb
@@ -27,6 +27,7 @@ class Bag < ApplicationRecord
   end
 
   def upload_link
+    raise RuntimeError, "cannot upload a completed bag" if storage_location
     File.join(Rails.application.config.upload['rsync_point'],bag_id)
   end
 

--- a/app/views/v1/bags/_bag.json.jbuilder
+++ b/app/views/v1/bags/_bag.json.jbuilder
@@ -2,7 +2,9 @@ json.bag_id bag.bag_id
 json.user bag.user.username
 json.content_type bag.content_type
 json.external_id bag.external_id
-json.upload_link bag.upload_link
+unless bag.storage_location
+  json.upload_link bag.upload_link
+end
 if @current_user&.admin?
   json.storage_location bag.storage_location
 end

--- a/config/infrastructure.yml
+++ b/config/infrastructure.yml
@@ -1,0 +1,8 @@
+development:
+  database: db/development.sqlite3
+
+test:
+  database: db/test.sqlite3
+
+production:
+  database: db/production.sqlite3

--- a/lib/bag_rsyncer.rb
+++ b/lib/bag_rsyncer.rb
@@ -1,0 +1,15 @@
+class BagRsyncer
+  def initialize(bag_path)
+    @bag_path = bag_path.chomp('/')
+  end
+
+  def upload(dest)
+    raise RuntimeError, 'rsync failed' unless
+    system('rsync','-avz',"#{bag_path}/",dest)
+  end
+
+  private
+
+  attr_accessor :bag_path
+end
+

--- a/lib/chipmunk_service.rb
+++ b/lib/chipmunk_service.rb
@@ -1,0 +1,60 @@
+require "rest_client"
+
+class ChipmunkServiceError < RuntimeError
+  def initialize(rest_error)
+    @rest_error = rest_error 
+    super(rest_error.message)
+  end
+
+  def service_exception
+    JSON.parse(rest_error.response)["exception"]
+  end
+
+  private
+
+  attr_reader :rest_error
+end
+
+class ChipmunkService
+
+  def initialize(url: 'http://localhost:3000',api_key: )
+    @url = url
+    @api_key = api_key
+  end
+
+  def post(endpoint,params = {})
+    request(:post,endpoint,payload: params)
+  end
+
+  def get(endpoint)
+    request(:get,endpoint)
+  end
+
+  private
+
+  attr_accessor :url, :api_key
+
+  def request(method,endpoint,**kwargs)
+    begin
+      response = RestClient::Request.execute(method: method, 
+                                  url: url + endpoint,
+                                  headers: auth_header,
+                                  **kwargs)
+      
+      # Manually follows the redirect from a 201 response
+      # if needed and returns the result as a JSON object.
+      if response.net_http_res.is_a? Net::HTTPCreated
+        response = response.follow_get_redirection
+      end
+
+      JSON.parse(response)
+    rescue RestClient::InternalServerError => e
+      raise ChipmunkServiceError.new(e)
+    end
+  end
+
+  def auth_header
+    { Authorization: "Token token=#{api_key}" }
+  end
+
+end

--- a/lib/uploader.rb
+++ b/lib/uploader.rb
@@ -3,21 +3,34 @@ require 'rest-client'
 require 'pry'
 require 'json'
 require_relative './chipmunk_bag'
-
-CHIPMUNK_URL = "http://localhost:3000"
+require_relative './chipmunk_service'
+require_relative './bag_rsyncer'
 
 class Uploader
-  def initialize(api_key,bag_path)
-    @api_key = api_key
+  def initialize(api_key,bag_path,service: ChipmunkService.new(api_key: api_key),rsyncer: BagRsyncer.new(bag_path))
     @bag_path = bag_path.chomp('/')
     @request_params = request_params_from_bag(bag_path)
+    @service = service
+    @rsyncer = rsyncer
   end
 
   def upload
-    req = make_request
-    rsync_bag(req["upload_link"])
-    qitem = complete_request(req)
-    print_result(wait_for_bag(qitem))
+    begin
+      req = make_request
+
+      if !req["upload_link"]
+        puts "Bag is already uploaded"
+        exit 1
+      end
+
+      rsyncer.upload(req["upload_link"])
+      qitem = complete_request(req)
+      print_result(wait_for_bag(qitem))
+    rescue ChipmunkServiceError => e
+      puts e.to_s
+      puts e.service_exception
+      exit 1
+    end
   end
 
   def bag_id
@@ -26,11 +39,11 @@ class Uploader
 
   private
 
-  attr_accessor :request_params, :api_key, :bag_path
+  attr_accessor :request_params, :bag_path, :service, :rsyncer
 
   def print_result(qitem_result)
     if qitem_result["status"] == "DONE"
-      pp chipmunk_get(qitem_result["bag"])
+      pp service.get(qitem_result["bag"])
     else
       pp qitem_result
     end
@@ -56,24 +69,12 @@ class Uploader
      bag_id: tags['Bag-ID']}
   end
 
-  def auth_header
-    { Authorization: "Token token=#{api_key}" }
-  end
-
-
   def make_request
-    chipmunk_post("/v1/requests", request_params)
-  end
-
-  def rsync_bag(upload_link)
-    # append trailing / to bag path here so we actually put the bag instead of
-    # a directory containing the bag in the upload target
-    raise RuntimeError, 'rsync failed' unless
-      system('rsync','-avz',"#{bag_path}/",upload_link)
+    service.post("/v1/requests", request_params)
   end
 
   def complete_request(request)
-    chipmunk_post("/v1/requests/#{bag_id}/complete")
+    service.post("/v1/requests/#{bag_id}/complete")
   end
 
   def wait_for_bag(qitem)
@@ -83,39 +84,8 @@ class Uploader
       return result if result["status"] != "PENDING"
       puts "Waiting for queue item to be processed"
       sleep 10
-      result = chipmunk_get("/v1/queue/#{qitem["id"]}")
+      result = service.get("/v1/queue/#{qitem["id"]}")
     end
   end
 
-  def chipmunk_post(endpoint,params = {})
-    chipmunk_request(:post,endpoint,payload: params)
-  end
-
-  def chipmunk_get(endpoint)
-    chipmunk_request(:get,endpoint)
-  end
-  
-  # Manually follows the redirect from a 201 response
-  # if needed and returns the result as a JSON object.
-  def follow_redir_and_parse(response) 
-    # follow redirection from 201; avoid magic integer
-    if response.net_http_res.is_a? Net::HTTPCreated
-      response = response.follow_get_redirection
-    end
-
-    JSON.parse(response)
-  end
-
-  def chipmunk_request(method,endpoint,**kwargs)
-    begin
-    follow_redir_and_parse(RestClient::Request.execute(method: method, 
-                                url: CHIPMUNK_URL + endpoint,
-                                headers: auth_header,
-                                **kwargs))
-    rescue RestClient::InternalServerError => e
-      puts e.to_s
-      puts JSON.parse(e.response)["exception"]
-      exit 1
-    end
-  end
 end

--- a/spec/chipmunk_service_spec.rb
+++ b/spec/chipmunk_service_spec.rb
@@ -1,0 +1,83 @@
+require "spec_helper"
+
+describe ChipmunkService do
+  let(:url) { "https://www.example.com" }
+  let(:api_key) { 'mykey' }
+  subject { ChipmunkService.new(url: url, api_key: api_key) }
+
+  shared_examples_for "a ChipmunkService http method" do |method|
+    it "parses the response" do 
+      stub_request(method, "#{url}/something")
+        .to_return({ body: '{"foo":"bar"}' })
+
+      expect(subject.public_send(method,'/something')).to eql({ "foo" => "bar"})
+    end
+
+    it "follows 201 redirection" do
+      stub_request(method, "#{url}/something")
+        .to_return(status: 201, headers: { 'Location' => "#{url}/elsewhere" })
+      stub_request(:get, "#{url}/elsewhere")
+        .to_return({ body: '{}' })
+
+      subject.public_send(method,'/something')
+
+      expect(a_request(:get, "#{url}/elsewhere"))
+        .to have_been_requested
+    end
+
+    it "handles errors by raising a ChipmunkServiceError" do
+      stub_request(method, "#{url}/error")
+        .to_return(status: 500, body: '{}' )
+
+      expect{subject.public_send(method,"/error")}
+        .to raise_exception(ChipmunkServiceError)
+    end
+
+    it "handles errors by raising an error that encapsulates the returned error" do
+      stub_request(method, "#{url}/error")
+        .to_return(status: 500, body: '{ "exception": "some problem" }' )
+
+      expect{subject.public_send(method,"/error")}
+        .to raise_exception do |error|
+        expect(error.service_exception).to match(/some problem/)
+      end
+    end
+
+    it "uses the provided auth header" do
+      stub_request(method, url)
+        .to_return({ body: '{}' })
+
+      subject.public_send(method,'/')
+      expect(a_request(method, url)
+        .with(headers: { 'Authorization' => "Token token=#{api_key}" }))
+        .to have_been_requested
+    end
+  end
+
+  describe '#post' do
+    it "makes the request with the given parameters" do
+      stub_request(:post, url)
+        .to_return({ body: '{}' })
+
+      subject.post('/', { foo: "bar" })
+      expect(a_request(:post, url)
+        .with(body: { "foo" => "bar" }))
+        .to have_been_requested
+    end
+
+    it_behaves_like "a ChipmunkService http method", :post
+  end
+
+  describe '#get' do
+    it "makes the request" do
+      stub_request(:get, url)
+        .to_return({ body: '{}' })
+
+      subject.get('/')
+      expect(a_request(:get, url))
+        .to have_been_requested
+    end
+
+    it_behaves_like "a ChipmunkService http method", :get
+  end
+end

--- a/spec/features/end_to_end.feature
+++ b/spec/features/end_to_end.feature
@@ -58,8 +58,6 @@ Feature: End to End functionality
       | user          | <username>                           |
       | content_type  | audio                                |
       | external_id   | <external_id>                        |
-      # see PFDR-66 (this is present for completed bags after the request/bag merger)
-      | upload_link   | localhost:/tmp/chipmunk/inc/<bag_id> |
       | created_at    | 2017-05-17 18:49:08 UTC              |
       | updated_at    | 2017-05-17 18:49:08 UTC              |
       # see PFDR-66 (this fails after the request/bag merger)

--- a/spec/models/bag_spec.rb
+++ b/spec/models/bag_spec.rb
@@ -49,9 +49,16 @@ RSpec.describe Bag, type: :model do
     end
   end
 
-  it "has an upload link based on the rsync point and bag id" do
-    request = Fabricate.build(:bag, bag_id: uuid)
-    expect(request.upload_link).to eq(File.join(upload_link,uuid))
+  describe "#upload_link" do
+    it "has an upload link based on the rsync point and bag id if there is no storage location" do
+      request = Fabricate.build(:bag, bag_id: uuid, storage_location: nil)
+      expect(request.upload_link).to eq(File.join(upload_link,uuid))
+    end
+
+    it "raises an exception if the upload link is requested for a completed bag" do
+      request = Fabricate.build(:bag, storage_location: "it/exists")
+      expect{request.upload_link}.to raise_error RuntimeError
+    end
   end
 
   describe "#external_validation_cmd" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,7 @@ end
 
 # Load Turnip. The rest of the config is in the turnip_helper.rb
 require "turnip/rspec"
+require "webmock/rspec"
 
 def fixture(*path)
   File.join(Rails.application.root,"spec","support","fixtures",File.join(*path))

--- a/spec/upload_spec.rb
+++ b/spec/upload_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+describe Uploader do
+
+  let(:mock_service) do
+    instance_double(ChipmunkService, post: {}, get: {}) 
+  end
+  let(:mock_rsyncer) { instance_double(BagRsyncer,upload: true) }
+  let(:mock_request) { Fabricate.attributes_for(:request) }
+  let(:item_id) { mock_request["item_id"] }
+      
+  before(:each) do 
+    allow(mock_service).to receive(:post)
+      .with("/v1/requests",anything)
+      .and_return(mock_request)
+
+    allow(mock_service).to receive(:get)
+      .with("/v1/queue/#{item_id}")
+      .and_return( { status: "DONE" } )
+  end
+
+  subject do
+    described_class.new("foo",fixture('test_bag'),service: mock_service, rsyncer: mock_rsyncer)
+  end
+
+  context "when the request has an upload link" do
+    before(:each) { mock_request["upload_link"] = '/some/path' }
+
+    it "uploads the bag" do
+      expect(mock_rsyncer).to receive(:upload).with(mock_request["upload_link"])
+      subject.upload
+		end
+  end
+
+  context "when the request has no upload link" do
+    before(:each) { mock_request.delete("upload_link") }
+
+    it "does not attempt to upload the bag" do
+      expect(mock_rsyncer).not_to receive(:upload)
+      subject.upload
+    end
+  end
+
+  context "when something goes wrong" do
+    let(:rest_error) do
+      double(:rest_error,response: '{ "exception": "some problem"}')
+    end
+
+    before(:each) do 
+      allow(mock_service).to receive(:post).and_raise(ChipmunkError.new(rest_error))
+    end
+
+    it "prints the error message" do
+      expect{subject}.to output(/some problem/).to_stdout
+    end
+  end
+end

--- a/spec/views/v1/bags/a_bag_view.rb
+++ b/spec/views/v1/bags/a_bag_view.rb
@@ -1,0 +1,64 @@
+RSpec.shared_examples_for "a bag view"  do |assignee,wrapper|
+  let(:bag) do
+    double(:bag,
+      bag_id: SecureRandom.uuid,
+      user: double(:user, username: Faker::Internet.user_name),
+      external_id: SecureRandom.uuid,
+      storage_location: nil,
+      external_service: "mirlyn",
+      upload_link: "#{Faker::Internet.email}:/#{Faker::Lorem.word}/path",
+      content_type: "fake",
+      created_at: Time.at(0),
+      updated_at: Time.now
+    )
+  end
+  let(:expected) do
+    {
+      bag_id: bag.bag_id,
+      user: bag.user.username,
+      external_id: bag.external_id,
+      content_type: bag.content_type,
+      created_at: bag.created_at.to_formatted_s(:default),
+      updated_at: bag.updated_at.to_formatted_s(:default)
+    }
+  end
+  let(:admin_user) { double(:admin_user, admin?: true) }
+  let(:unprivileged_user) { double(:unpriv_user, admin?: false) }
+
+
+  before(:each) do
+    assign(assignee, wrapper.call(bag))
+  end
+
+  context "with a completed bag (has storage location)" do
+    before(:each) do
+      allow(bag).to receive(:storage_location)
+        .and_return "#{Faker::Lorem.word}/path"
+    end
+
+    context "when the user is underprivileged" do
+      before(:each) { assign(:current_user, unprivileged_user) }
+      it "renders correct json w/o storage_location" do
+        render
+        expect(JSON.parse(rendered, symbolize_names: true)).to eql(wrapper.call(expected))
+      end
+    end
+
+    context "when the user is an admin" do
+      before(:each) { assign(:current_user, admin_user) }
+      it "renders correct json w/ storage_location" do
+        render
+        expect(JSON.parse(rendered, symbolize_names: true))
+          .to eql wrapper.call(expected.merge({storage_location: bag.storage_location}))
+      end
+    end
+  end
+
+  context "with an incomplete bag (no storage location)" do
+    it "renders correct json w/ upload_link" do
+      render
+      expect(JSON.parse(rendered, symbolize_names: true))
+        .to eql wrapper.call(expected.merge({upload_link: bag.upload_link}))
+    end
+  end
+end

--- a/spec/views/v1/bags/index.json.jbuilder_spec.rb
+++ b/spec/views/v1/bags/index.json.jbuilder_spec.rb
@@ -1,50 +1,6 @@
 require "rails_helper"
+require_relative "./a_bag_view"
 
 describe "/v1/bags/index.json.jbuilder" do
-  let(:bag) do
-    double(:bag,
-      bag_id: SecureRandom.uuid,
-      user: double(:user, username: Faker::Internet.user_name),
-      external_id: SecureRandom.uuid,
-      storage_location: "#{Faker::Lorem.word}/path",
-      external_service: "mirlyn",
-      upload_link: "#{Faker::Internet.email}:/#{Faker::Lorem.word}/path",
-      content_type: "fake",
-      created_at: Time.at(0),
-      updated_at: Time.now
-    )
-  end
-  let(:expected) do
-    {
-      bag_id: bag.bag_id,
-      user: bag.user.username,
-      external_id: bag.external_id,
-      content_type: bag.content_type,
-      upload_link: bag.upload_link,
-      created_at: bag.created_at.to_formatted_s(:default),
-      updated_at: bag.updated_at.to_formatted_s(:default)
-    }
-  end
-  let(:admin_user) { double(:admin_user, admin?: true) }
-  let(:unprivileged_user) { double(:unpriv_user, admin?: false) }
-
-
-  context "when the user is underprivileged" do
-    before(:each) { assign(:current_user, unprivileged_user) }
-    it "renders correct json w/o storage_location" do
-      assign(:bags, [bag])
-      render
-      expect(JSON.parse(rendered, symbolize_names: true)).to eql([expected])
-    end
-  end
-
-  context "when the user is an admin" do
-    before(:each) { assign(:current_user, admin_user) }
-    it "renders correct json w/ storage_location" do
-      assign(:bags, [bag])
-      render
-      expect(JSON.parse(rendered, symbolize_names: true))
-        .to eql [expected.merge({storage_location: bag.storage_location})]
-    end
-  end
+  it_behaves_like "a bag view", :bags, ->(bag) { [bag] }
 end

--- a/spec/views/v1/bags/show.json.jbuilder_spec.rb
+++ b/spec/views/v1/bags/show.json.jbuilder_spec.rb
@@ -1,50 +1,6 @@
 require "rails_helper"
+require_relative "./a_bag_view"
 
 describe "/v1/bags/show.json.jbuilder" do
-  let(:bag) do
-    double(:bag,
-      bag_id: SecureRandom.uuid,
-      user: double(:user, username: Faker::Internet.user_name),
-      external_id: SecureRandom.uuid,
-      storage_location: "#{Faker::Lorem.word}/path",
-      external_service: "mirlyn",
-      upload_link: "#{Faker::Internet.email}:/#{Faker::Lorem.word}/path",
-      content_type: "fake",
-      created_at: Time.at(0),
-      updated_at: Time.now
-    )
-  end
-  let(:expected) do
-    {
-      bag_id: bag.bag_id,
-      user: bag.user.username,
-      external_id: bag.external_id,
-      upload_link: bag.upload_link,
-      content_type: bag.content_type,
-      created_at: bag.created_at.to_formatted_s(:default),
-      updated_at: bag.updated_at.to_formatted_s(:default)
-    }
-  end
-  let(:admin_user) { double(:admin_user, admin?: true) }
-  let(:unprivileged_user) { double(:unpriv_user, admin?: false) }
-
-
-  context "when the user is underprivileged" do
-    before(:each) { assign(:current_user, unprivileged_user) }
-    it "renders correct json w/o storage_location" do
-      assign(:bag, bag)
-      render
-      expect(JSON.parse(rendered, symbolize_names: true)).to eql(expected)
-    end
-  end
-
-  context "when the user is an admin" do
-    before(:each) { assign(:current_user, admin_user) }
-    it "renders correct json w/ storage_location" do
-      assign(:bag, bag)
-      render
-      expect(JSON.parse(rendered, symbolize_names: true))
-        .to eql expected.merge({storage_location: bag.storage_location})
-    end
-  end
+  it_behaves_like "a bag view", :bag, ->(bag) { bag }
 end


### PR DESCRIPTION
As written the bug is about the behavior of the upload script, but I think the way it's addressed here is more appropriate - the views simply don't provide an upload link if the bag has been completed. We don't have any specs for the upload script, but I think the behavior with this PR will be to give an odd rsync error if the upload link is missing. Definitely worth testing manually.