### PR TITLE
PFDR-80 - don't upload if bag is already uploaded

### DIFF
--- a/app/models/bag.rb
+++ b/app/models/bag.rb
@@ -30,6 +30,10 @@ class Bag < ApplicationRecord
     File.join(Rails.application.config.upload['rsync_point'],bag_id)
   end
 
+  def stored?
+    storage_location != nil
+  end
+
   def external_validation_cmd
     [Rails.application.config.validation[content_type.to_s],external_id,src_path].join(" ")
   end

--- a/app/views/v1/bags/_bag.json.jbuilder
+++ b/app/views/v1/bags/_bag.json.jbuilder
@@ -6,5 +6,6 @@ json.upload_link bag.upload_link
 if @current_user&.admin?
   json.storage_location bag.storage_location
 end
+json.stored bag.stored?
 json.created_at bag.created_at.to_formatted_s(:default)
 json.updated_at bag.updated_at.to_formatted_s(:default)

--- a/lib/uploader.rb
+++ b/lib/uploader.rb
@@ -7,10 +7,10 @@ require_relative './chipmunk_client'
 require_relative './bag_rsyncer'
 
 class Uploader
-  def initialize(api_key,bag_path,service: ChipmunkClient.new(api_key: api_key),rsyncer: BagRsyncer.new(bag_path))
+  def initialize(api_key,bag_path,client: ChipmunkClient.new(api_key: api_key),rsyncer: BagRsyncer.new(bag_path))
     @bag_path = bag_path.chomp('/')
     @request_params = request_params_from_bag(bag_path)
-    @service = service
+    @client = client
     @rsyncer = rsyncer
   end
 
@@ -36,11 +36,11 @@ class Uploader
 
   private
 
-  attr_accessor :request_params, :bag_path, :service, :rsyncer
+  attr_accessor :request_params, :bag_path, :client, :rsyncer
 
   def print_result(qitem_result)
     if qitem_result["status"] == "DONE"
-      pp service.get(qitem_result["bag"])
+      pp client.get(qitem_result["bag"])
     else
       pp qitem_result
     end
@@ -67,11 +67,11 @@ class Uploader
   end
 
   def make_request
-    service.post("/v1/requests", request_params)
+    client.post("/v1/requests", request_params)
   end
 
   def complete_request(request)
-    service.post("/v1/requests/#{bag_id}/complete")
+    client.post("/v1/requests/#{bag_id}/complete")
   end
 
   def wait_for_bag(qitem)
@@ -81,7 +81,7 @@ class Uploader
       return result if result["status"] != "PENDING"
       puts "Waiting for queue item to be processed"
       sleep 10
-      result = service.get("/v1/queue/#{qitem["id"]}")
+      result = client.get("/v1/queue/#{qitem["id"]}")
     end
   end
 

--- a/lib/uploader.rb
+++ b/lib/uploader.rb
@@ -17,13 +17,16 @@ class Uploader
   def upload
     begin
       req = make_request
+      if req["stored"]
+        puts "Bag has already been uploaded"
+        return
+      end
       rsyncer.upload(req["upload_link"])
       qitem = complete_request(req)
       print_result(wait_for_bag(qitem))
     rescue ChipmunkClientError => e
       puts e.to_s
       puts e.service_exception
-      exit 1
     end
   end
 

--- a/spec/features/end_to_end.feature
+++ b/spec/features/end_to_end.feature
@@ -31,6 +31,7 @@ Feature: End to End functionality
       | user          | <username>                           |
       | content_type  | audio                                |
       | external_id   | <external_id>                        |
+      | stored        | false                                |
       | upload_link   | localhost:/tmp/chipmunk/inc/<bag_id> |
       | created_at    | 2017-05-17 18:49:08 UTC              |
       | updated_at    | 2017-05-17 18:49:08 UTC              |
@@ -59,6 +60,7 @@ Feature: End to End functionality
       | content_type  | audio                                |
       | external_id   | <external_id>                        |
       # see PFDR-66 (this is present for completed bags after the request/bag merger)
+      | stored        | true                                 |
       | upload_link   | localhost:/tmp/chipmunk/inc/<bag_id> |
       | created_at    | 2017-05-17 18:49:08 UTC              |
       | updated_at    | 2017-05-17 18:49:08 UTC              |

--- a/spec/support/step_definitions/request_steps.rb
+++ b/spec/support/step_definitions/request_steps.rb
@@ -44,6 +44,7 @@ module RequestSteps
 
   def adjust_table_hash(hash)
     hash["id"] ? hash["id"] = Integer(hash["id"]) : nil
+    hash["stored"] ? hash["stored"] = ActiveModel::Type::Boolean.new.cast(hash["stored"]) : nil
     return hash
   end
 end

--- a/spec/upload_spec.rb
+++ b/spec/upload_spec.rb
@@ -3,13 +3,24 @@ require "spec_helper"
 describe Uploader do
 
   let(:mock_service) do
-    instance_double(ChipmunkClient, post: {}, get: {}) 
+    instance_double(ChipmunkClient, post: {}, get: {})
   end
   let(:mock_rsyncer) { instance_double(BagRsyncer,upload: true) }
-  let(:mock_request) { Fabricate.attributes_for(:request) }
+  let(:mock_request) {
+    {
+      bag_id: SecureRandom.uuid,
+      user: Faker::Internet.user_name,
+      external_id: SecureRandom.uuid,
+      content_type: "fake",
+      upload_link: "#{Faker::Internet.email}:/#{Faker::Lorem.word}/path",
+      created_at: Time.at(0),
+      updated_at: Time.now
+    }
+  }
+
   let(:item_id) { mock_request["item_id"] }
-      
-  before(:each) do 
+
+  before(:each) do
     allow(mock_service).to receive(:post)
       .with("/v1/requests",anything)
       .and_return(mock_request)
@@ -23,9 +34,22 @@ describe Uploader do
     described_class.new("foo",fixture('test_bag'),service: mock_service, rsyncer: mock_rsyncer)
   end
 
-  it "uploads the bag" do
-    expect(mock_rsyncer).to receive(:upload).with(mock_request["upload_link"])
-    subject.upload
+  context "when the bag is not stored" do
+    before(:each) { mock_request["stored"] = false }
+
+    it "uploads the bag" do
+      expect(mock_rsyncer).to receive(:upload).with(mock_request["upload_link"])
+      subject.upload
+    end
+  end
+
+  context "when the bag is stored" do
+    before(:each) { mock_request["stored"] = true }
+
+    it "does not attempt to upload the bag" do
+      expect(mock_rsyncer).not_to receive(:upload)
+      subject.upload
+    end
   end
 
   context "when something goes wrong" do
@@ -35,7 +59,7 @@ describe Uploader do
              message: '599 Having a bad problem')
     end
 
-    before(:each) do 
+    before(:each) do
       allow(mock_service).to receive(:post).and_raise(ChipmunkClientError.new(rest_error))
     end
 

--- a/spec/views/v1/bags/a_bag_view.rb
+++ b/spec/views/v1/bags/a_bag_view.rb
@@ -12,7 +12,8 @@ RSpec.shared_examples_for "a bag view"  do |assignee,wrapper|
       upload_link: "#{Faker::Internet.email}:/#{Faker::Lorem.word}/path",
       content_type: "fake",
       created_at: Time.at(0),
-      updated_at: Time.now
+      updated_at: Time.now,
+      stored?: true
     )
   end
   let(:expected) do
@@ -23,7 +24,8 @@ RSpec.shared_examples_for "a bag view"  do |assignee,wrapper|
       content_type: bag.content_type,
       upload_link: bag.upload_link,
       created_at: bag.created_at.to_formatted_s(:default),
-      updated_at: bag.updated_at.to_formatted_s(:default)
+      updated_at: bag.updated_at.to_formatted_s(:default),
+      stored: bag.stored?
     }
   end
   let(:admin_user) { double(:admin_user, admin?: true) }


### PR DESCRIPTION
completely revamped version of the intention from #23 - adds a "stored?" method on the bag, exposes that in the view, and checks it when uploading.