### PR TITLE
Fix issues with Rails application config getting overwritten in tests

### DIFF
--- a/config/upload.yml
+++ b/config/upload.yml
@@ -8,8 +8,8 @@ development:
 
 test:
   # application-writable directory where upload points should be created, e.g. /pfdr/incoming/uniqname
-  upload_path: /pfdr/incoming/
+  upload_path: /tmp/pfdr/incoming/
   # rsync point to user-writable upload path
   rsync_point: localhost:incoming
   # application-writable directory for final storage of bags; allows creation of dirs, files
-  storage_path: /pfdr/storage/
+  storage_path: /tmp/pfdr/storage/

--- a/spec/support/examples/a_validation_integration.rb
+++ b/spec/support/examples/a_validation_integration.rb
@@ -16,10 +16,17 @@ RSpec.shared_examples 'a validation integration' do
   end
 
   before(:each) do
+    @old_validation = Rails.application.config.validation[content_type]
+    @old_upload_path = Rails.application.config.upload['upload_path']
     Rails.application.config.validation[content_type] = File.join(Rails.application.root,"bin",validation_script)
     Rails.application.config.upload['upload_path'] = fixture(content_type)
     # don't actually move the bag
     allow(File).to receive(:rename).with(bag.src_path,bag.dest_path).and_return true
+  end
+
+  after(:each) do
+    Rails.application.config.validation[content_type] = @old_validation
+    Rails.application.config.upload['upload_path'] = @old_upload_path
   end
 
   # for known upload location under fixtures/video

--- a/spec/turnip_helper.rb
+++ b/spec/turnip_helper.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "pry"
 
 module TurnipHelper
   include Rack::Test::Methods
@@ -10,6 +11,15 @@ end
 
 RSpec.configure do |config|
   config.include TurnipHelper, type: :feature
+
+  config.before(:type => :feature) do
+    @old_upload_config = Rails.application.config.upload.clone
+    @old_validation_config = Rails.application.config.validation.clone
+  end
+  config.after(:type => :feature) do
+    Rails.application.config.upload = @old_upload_config
+    Rails.application.config.validation = @old_validation_config
+  end
 end
 
 require_relative "support/step_definitions/placeholders"


### PR DESCRIPTION
Also: use a test upload/storage path by default that's more likely to be writable