### PR TITLE
PFDR-83: Ability to batch upload material

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,50 @@ A Preservation-Focused Dark Repository for the University of Michigan
 - `git clone`/`bundle install` as usual
 - Set up the database: `bundle exec rake db:setup`
 - Set up the repository and upload paths: `bundle exec rake chipmunk:setup`
-- `export CHIPMUNK_API_KEY=the generated key`
+- Set up external validators in `config/validation.yml` - for a simple test try using `/bin/true`
 - In another window, start the development server: `bundle exec rails server`
+- In another window, start the resque pool: `bundle exec rake resque:pool`
 - (Optional) Bag some audio content: `bundle exec ruby -I lib bin/makebag audio 39015012345678 /path/to/audio/material /path/to/output/bag`
 - Try to upload a test bag: `bundle exec ruby -I lib bin/upload spec/support/fixtures/audio/upload/good` (or whatever bag you created before)
 
+## Usage
+
+### Server setup
+
+- (Optional) Set up a mysql database and configure appropriately in `config/database.yml`
+- Set the Rails secret key in `config/secrets.yml` or via `$SECRET_KEY_BASE`
+- Configure storage paths
+- Configure external validators (see "Validators" below)
+- Start Rails (`bundle exec rails server`)
+- Start resque (`bundle exec rake resque:pool`)
+- Create a user (current at the rails console)
+- Ensure client can connect to rails server.
+
+### Client setup
+
+- User should be able to connect via rsync over ssh to the configured rsync point in `config/upload.yml`
+- Create `config/client.yml` as follows:
+
+```yaml
+api_key: API_KEY_FROM_USER_SETUP_ABOVE
+# should be the full URL to the Chipmunk server; defaults to http://localhost:3000
+url: http://localhost:3000
+```
+
+### Client usage
+
+- `bin/upload -c path/to/config.yml /path/to/bag1 /path/to/bag2`
+
+If no config file is specified, it will use `config/client.yml` by default.
+
+The client will display progress on uploading and validating each bag in sequence.
+
+## Validators
+
+An external validator should accept as parameters:
+
+- The external ID (i.e. a barcode or other identifier)
+- The path to the bag
+
+The validator should return zero if the bag is valid and non-zero if the bag is
+not valid. Any output or errors will be captured for inspection by the client.

--- a/bin/upload
+++ b/bin/upload
@@ -1,12 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative "../lib/uploader"
+require_relative "../lib/chipmunk_cli"
 
-API_KEY = ENV["CHIPMUNK_API_KEY"]
-
-bag_path = ARGV[0]
-
-raise ArgumentError, "Usage: #{$PROGRAM_NAME} /path/to/bag" unless bag_path
-
-Uploader.new(API_KEY, bag_path).upload
+ChipmunkCLI.new(ARGV).run

--- a/config/client.yml.example
+++ b/config/client.yml.example
@@ -1,0 +1,2 @@
+url: http://localhost:3000
+api_key: REPLACE_ME

--- a/lib/chipmunk_cli.rb
+++ b/lib/chipmunk_cli.rb
@@ -1,0 +1,53 @@
+require 'optparse'
+require 'active_support/core_ext/hash'
+require 'yaml'
+require_relative './chipmunk_client'
+require_relative './uploader'
+
+class ChipmunkCLI
+  def initialize(args)
+    parse_options
+    load_default_config
+
+    @config = @config.symbolize_keys.slice(:uri,:api_key)
+    config[:api_key] = ENV["CHIPMUNK_API_KEY"] if ENV["CHIPMUNK_API_KEY"]
+
+    @client = ChipmunkClient.new(**config)
+  end
+
+  def run
+    bag_paths.each do |bag_path|
+      puts "Uploading #{bag_path}"
+      Uploader.new(bag_path, client: client).upload
+      puts
+    end
+  end
+
+  private
+
+  attr_reader :client, :config, :bag_paths
+
+  def parse_options
+    OptionParser.new do |opts|
+      opts.banner = "Usage: #{$PROGRAM_NAME} [options] /path/to/bag1 /path/to/bag2 ..."
+
+      opts.on("-c", "--config", "Configuration file") do |c|
+        @config = YAML.load(File.read(c))
+      end
+    end
+
+    raise ArgumentError, "Usage: #{$PROGRAM_NAME} " if ARGV.empty?
+
+    @bag_paths = ARGV
+  end
+
+  def load_default_config
+    default_config = "#{File.dirname(__FILE__)}/../config/client.yml"
+    if File.exists?(default_config) and !@config
+      @config = YAML.load(File.read(default_config)) 
+    else
+      @config = {}
+    end
+  end
+
+end

--- a/lib/tasks/chipmunk_setup.rake
+++ b/lib/tasks/chipmunk_setup.rake
@@ -10,7 +10,7 @@ namespace :chipmunk do
     FileUtils.symlink(app_upload_user_path, user_upload_path) unless File.exist?(user_upload_path)
   end
 
-  def update_config(upload_config_path, app_storage_path, app_upload_path, user_upload_path)
+  def set_upload_config(upload_config_path, app_storage_path, app_upload_path, user_upload_path)
     # update upload.yml
     upload_config = YAML.load_file(upload_config_path)
     upload_config[Rails.env]["rsync_point"] = "localhost:#{user_upload_path}"
@@ -22,16 +22,15 @@ namespace :chipmunk do
     puts
   end
 
-  def print_user_api_key(username)
+  def set_client_config(username,client_config_path)
     # find/create user
     user = User.find_by_username(username)
     unless user
       user = User.create(username: username, email: "nobody@nowhere")
       user.save
     end
-    puts "User API key for #{user.username}"
-    puts "  export CHIPMUNK_API_KEY=#{user.api_key}"
-    puts
+    puts "User API key for #{user.username}: #{user.api_key}"
+    YAML.dump({ "api_key" => user.api_key}, File.new(client_config_path, "w"))
   end
 
   task setup: :environment do
@@ -40,13 +39,14 @@ namespace :chipmunk do
     app_upload_path = "#{Rails.root}/repo/incoming"
     user_upload_path = "#{Rails.root}/incoming"
     upload_config_path = "#{Rails.root}/config/upload.yml"
+    client_config_path = "#{Rails.root}/config/client.yml"
 
     create_paths(app_storage_path, "#{app_upload_path}/#{username}", user_upload_path)
-    update_config(upload_config_path, app_storage_path, app_upload_path, user_upload_path)
+    set_upload_config(upload_config_path, app_storage_path, app_upload_path, user_upload_path)
     puts "Ensure #{username} can rsync via ssh with write access to:"
     puts "  localhost:#{user_upload_path}"
     puts
 
-    print_user_api_key(username)
+    set_client_config(username,client_config_path)
   end
 end

--- a/lib/uploader.rb
+++ b/lib/uploader.rb
@@ -9,7 +9,7 @@ require_relative "./chipmunk_client"
 require_relative "./bag_rsyncer"
 
 class Uploader
-  def initialize(api_key, bag_path, client: ChipmunkClient.new(api_key: api_key), rsyncer: BagRsyncer.new(bag_path))
+  def initialize(bag_path, client:, rsyncer: BagRsyncer.new(bag_path))
     @bag_path = bag_path.chomp("/")
     @request_params = request_params_from_bag(bag_path)
     @client = client
@@ -37,7 +37,7 @@ class Uploader
 
   def check_request(request)
     if request["stored"]
-      puts "Bag has already been uploaded"
+      puts "Bag for #{request["external_id"]} has already been uploaded"
       false
     elsif external_id != request["external_id"]
       puts "Server expected a bag with external ID \"#{request["external_id"]}\" but the provided bag has external ID \"#{external_id}\""
@@ -53,7 +53,7 @@ class Uploader
       true
     else
       puts "#{external_id} upload failure"
-      puts qitem_result[:error]
+      puts qitem_result["error"]
       false
     end
   end

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -35,7 +35,7 @@ describe Uploader do
   end
 
   subject do
-    described_class.new("foo", fixture("test_bag"), client: client, rsyncer: rsyncer)
+    described_class.new(fixture("test_bag"), client: client, rsyncer: rsyncer)
   end
 
   context "when the bag is not already stored" do
@@ -59,8 +59,8 @@ describe Uploader do
     context "when bag validation fails" do
       let(:queue_item) do
         {
-          status: "ERROR",
-          error:  "something went wrong\n" \
+          "status" => "FAILED",
+          "error" =>  "something went wrong\n" \
             "here are the details"
         }
       end


### PR DESCRIPTION
- adds argument parsing & config loading in ChipmunkCLI (w/o specs)
- loads configuration (url and api key) from config/client.yml by
default & takes a config parameter
- updates chipmunk:setup rake task to use config/client.yml
- slightly changes display output format
- start to flesh out README
- fix bug in PFDR-82 specs & test (was using symbol instead of string
for hash key)