### PR TITLE
PFDR-89: Retrieve bags by external ID

### DIFF
--- a/app/controllers/v1/bags_controller.rb
+++ b/app/controllers/v1/bags_controller.rb
@@ -11,8 +11,10 @@ module V1
     end
 
     # GET /bags/1
+    # GET /bags/39015012345678
     def show
       @bag = Bag.find_by_bag_id(params[:bag_id])
+      @bag ||= Bag.find_by_external_id(params[:bag_id])
       authorize @bag
     end
 

--- a/spec/controllers/v1/bags_controller_spec.rb
+++ b/spec/controllers/v1/bags_controller_spec.rb
@@ -24,6 +24,20 @@ RSpec.describe V1::BagsController, type: :controller do
       end
     end
 
+    describe "GET #show/:external_id" do
+      context "as an admin" do
+        include_context "as admin user"
+        let(:bag) { Fabricate(:bag) }
+
+        it "can fetch a bag by external id" do
+          request.headers.merge! auth_header
+          get :show, params: { :bag_id => bag.external_id }
+
+          expect(assigns(:bag)).to eql(bag)
+        end
+      end
+    end
+
     describe "POST #create" do
       let(:attributes) do
         {


### PR DESCRIPTION
Allows the bag show endpoint to retrieve bags by external ID.

Although the external ID could in theory conflict with the internal ID, that should be rare.

I'm still interested in feedback on whether this is a reasonable way to do it - the alternative I suppose would be to create a route like `/bags/external_id/:external_id`, but I'm not really sure what would be the properly RESTful way to do that.