### PR TITLE
PFDR-99: Test policies are checked in controller actions

### DIFF
--- a/app/controllers/v1/events_controller.rb
+++ b/app/controllers/v1/events_controller.rb
@@ -3,7 +3,9 @@
 module V1
   class EventsController < ApplicationController
     def index
-      @events = EventsPolicy.new(current_user, Event.package(params[:bag_id])).resolve
+      policy = EventsPolicy.new(current_user, Event.package(params[:bag_id]))
+      policy.authorize! :index?
+      @events = policy.resolve
     end
   end
 end

--- a/app/controllers/v1/packages_controller.rb
+++ b/app/controllers/v1/packages_controller.rb
@@ -6,7 +6,10 @@ module V1
   class PackagesController < ApplicationController
     # GET /packages
     def index
-      @packages = PackagesPolicy.new(current_user).resolve
+      policy = PackagesPolicy.new(current_user)
+      policy.authorize! :index?
+
+      @packages = policy.resolve
     end
 
     # GET /packages/1

--- a/app/controllers/v1/queue_items_controller.rb
+++ b/app/controllers/v1/queue_items_controller.rb
@@ -6,7 +6,10 @@ module V1
   class QueueItemsController < ApplicationController
     # GET /v1/queue
     def index
-      @queue_items = QueueItemsPolicy.new(current_user).resolve
+      policy = QueueItemsPolicy.new(current_user)
+      policy.authorize! :index?
+
+      @queue_items = policy.resolve
     end
 
     # GET /v1/queue/:id

--- a/spec/controllers/v1/audits_controller_spec.rb
+++ b/spec/controllers/v1/audits_controller_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 
 RSpec.describe V1::AuditsController, type: :controller do
   describe "/v1" do
-    let!(:audit) { Fabricate(:audit) }
 
     describe "GET #show" do
+      let!(:audit) { Fabricate(:audit) }
       include_context "as admin user"
 
       it "assigns an audit presenter" do
@@ -23,9 +23,16 @@ RSpec.describe V1::AuditsController, type: :controller do
         get :show, params: { id: audit.id, expand: true }
         expect(assigns(:audit).expand?).to be true
       end
+      
+      it "checks the policy" do
+        expect_resource_policy_check(policy: AuditPolicy, user: user, resource: audit, action: :show?)
+
+        get :show, params: { id: audit.id }
+      end
     end
 
     describe "GET #index" do
+      let!(:audit) { Fabricate(:audit) }
       include_context "as admin user"
 
       it "assigns an array of audit presenters" do
@@ -37,10 +44,14 @@ RSpec.describe V1::AuditsController, type: :controller do
         get :index
         expect(assigns(:audits).first.expand?).to be false
       end
-    end
-  end
 
-  describe "/v1" do
+      it "checks the policy" do
+        expect_collection_policy_check(policy: AuditsPolicy, user: user, action: :index?)
+
+        get :index
+      end
+    end
+
     describe "POST #create" do
       # create two packages
       include_context "as admin user"
@@ -98,6 +109,12 @@ RSpec.describe V1::AuditsController, type: :controller do
       it "renders nothing" do
         post :create
         expect(response).to render_template(nil)
+      end
+
+      it "checks the policy" do
+        expect_collection_policy_check(policy: AuditsPolicy, user: user, action: :create?)
+
+        post :create
       end
     end
   end

--- a/spec/controllers/v1/events_controller_spec.rb
+++ b/spec/controllers/v1/events_controller_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe V1::EventsController, type: :controller do
   describe "/v1" do
     describe "GET #index" do
       it_behaves_like "an index endpoint" do
+        let(:policy) { EventsPolicy }
         let(:key) { :event_id }
         # for underprivileged users, should only render events where the package
         # belongs to the user

--- a/spec/policies/policy_helpers.rb
+++ b/spec/policies/policy_helpers.rb
@@ -85,3 +85,19 @@ def it_has_base_scope(scope)
     end
   end
 end
+
+def expect_resource_policy_check(policy:, resource:, user:, action:)
+  policy_double = double(:policy)
+  allow(policy).to receive(:new).with(user, resource).and_return(policy_double)
+  expect(policy_double).to receive(:authorize!).with(action)
+end
+
+def expect_collection_policy_check(policy:, user:, action:)
+  policy_double = double(:policy, resolve: [])
+
+  allow(policy).to receive(:new).with(user).and_return(policy_double)
+  # optional base scope
+  allow(policy).to receive(:new).with(user,anything).and_return(policy_double)
+
+  expect(policy_double).to receive(:authorize!).with(action)
+end

--- a/spec/support/examples/an_index_endpoint.rb
+++ b/spec/support/examples/an_index_endpoint.rb
@@ -11,25 +11,39 @@ RSpec.shared_examples "an index endpoint" do
 
   context "as underprivileged user" do
     include_context "as underprivileged user"
-    before(:each) { get :index, params: {} }
 
     it "returns 200" do
+      get :index
       expect(response).to have_http_status(200)
     end
+
     it "renders only the user's records" do
+      get :index
       expect(assigns(assignee)).to contain_exactly(mine)
     end
+
     it "renders the correct template" do
+      get :index
       expect(response).to render_template(template)
+    end
+
+    it "checks the policy" do
+      expect_collection_policy_check(policy: policy, user: user, action: :index?)
+      get :index
     end
   end
 
   context "as admin" do
     include_context "as admin user"
-    before(:each) { get :index, params: {} }
 
     it "renders all records" do
+      get :index
       expect(assigns(assignee)).to contain_exactly(mine, other)
+    end
+
+    it "checks the policy" do
+      expect_collection_policy_check(policy: policy, user: user, action: :index?)
+      get :index
     end
   end
 end


### PR DESCRIPTION
Adds a couple of helpers that mock the policy. It would be nicer to be able to inject a policy, but controller specs make this hard. Longer-term, we could think about adding something similar to Pundit where the controller raises an error if the policy wasn't checked, but this meets the need for now. This doesn't add anything with respect to ensuring the scope was properly resolved, but there are existing controller specs that cover that, albeit using the real policy rather than a mock one.