### PR TITLE
PFDR-133 - See queue items for a given package

### DIFF
--- a/app/controllers/v1/queue_items_controller.rb
+++ b/app/controllers/v1/queue_items_controller.rb
@@ -12,7 +12,7 @@ module V1
       policy = collection_policy.new(current_user)
       policy.authorize! :index?
 
-      @queue_items = policy.resolve
+      @queue_items = policy.resolve.for_package(params[:package])
     end
 
     # GET /v1/queue/:id

--- a/app/models/queue_item.rb
+++ b/app/models/queue_item.rb
@@ -19,4 +19,6 @@ class QueueItem < ApplicationRecord
     package.user
   end
 
+  scope :for_package, ->(package_id) { where(package_id: package_id) unless package_id.blank? }
+
 end

--- a/docs/v1/queue.rst
+++ b/docs/v1/queue.rst
@@ -9,7 +9,8 @@ v1/queue
     status ``FAILED``, and an array of errors.
 
     :reqheader Authorization: Bearer token
-    :parameter id: Queue item's id. This id is not the same as the bag's id.
+
+    :query package: Include only the results for the given package_id.
 
     :resheader Content-Type: application/json
     :resjsonarr id: Queue entry's id


### PR DESCRIPTION
This is set to merge to the docs branch for PFDR-121 / #51 as I included the documentation changes there.

I think it's reasonable to sit on this until PFDR-98 / #50 is merged.