### PR TITLE
PFDR-168 - integration tests for collection policy specs

### DIFF
--- a/spec/requests/v1/events_index_spec.rb
+++ b/spec/requests/v1/events_index_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "checkpoint_helper"
+
+RSpec.describe "GET /v1/events", :checkpoint_transaction, type: :request do
+  let(:key)  { Keycard::DigestKey.new }
+  let!(:user) { Fabricate(:user, api_key_digest: key.digest) }
+
+  let!(:video) { Fabricate(:package, content_type: 'video') }
+  let!(:audio) { Fabricate(:package, content_type: 'audio') }
+
+  let!(:event1) { Fabricate(:event, package: video) }
+  let!(:event2) { Fabricate(:event, package: video) }
+  let!(:event3) { Fabricate(:event, package: audio) }
+  let!(:event4) { Fabricate(:event, package: audio) }
+
+  let(:headers) do
+    { "Authorization"   => "Token token=#{key}" }
+  end
+
+  context "as an audio content manager" do
+    before(:each) do
+      Services.checkpoint.grant!(user,
+                                 Checkpoint::Credential::Role.new("content_manager"),
+                                 Checkpoint::Resource::AllOfType.new("audio"))
+    end
+
+    it "lists all events from audio packages" do
+      get "/v1/events", headers: headers
+
+      expect(JSON.parse(response.body).map { |i| i["id"] }).to contain_exactly(event3.id,event4.id)
+    end
+
+    xit "lists nothing when asked for events from a video package - pending PFDR-175"
+  end
+
+  context "as an admin" do
+    before(:each) do
+      Services.checkpoint.grant!(user,
+                                 Checkpoint::Credential::Role.new('admin'),
+                                 Checkpoint::Resource::AllOfAnyType.new)
+    end
+
+    it "lists all events" do
+      get "/v1/events", headers: headers
+
+      expect(JSON.parse(response.body).map { |i| i["id"] }).to contain_exactly(event1.id,event2.id,event3.id,event4.id)
+    end
+  end
+
+  context "as a user with no grants" do
+    it "returns a 403" do
+      get "/v1/events", headers: headers
+
+      expect(response.status).to eq(403)
+    end
+  end
+end

--- a/spec/requests/v1/events_index_spec.rb
+++ b/spec/requests/v1/events_index_spec.rb
@@ -10,10 +10,8 @@ RSpec.describe "GET /v1/events", :checkpoint_transaction, type: :request do
   let!(:video) { Fabricate(:package, content_type: 'video') }
   let!(:audio) { Fabricate(:package, content_type: 'audio') }
 
-  let!(:event1) { Fabricate(:event, package: video) }
-  let!(:event2) { Fabricate(:event, package: video) }
-  let!(:event3) { Fabricate(:event, package: audio) }
-  let!(:event4) { Fabricate(:event, package: audio) }
+  let!(:video_events) { Array.new(2) { Fabricate(:event, package: video) } }
+  let!(:audio_events) { Array.new(2) { Fabricate(:event, package: audio) } }
 
   let(:headers) do
     { "Authorization"   => "Token token=#{key}" }
@@ -29,7 +27,9 @@ RSpec.describe "GET /v1/events", :checkpoint_transaction, type: :request do
     it "lists all events from audio packages" do
       get "/v1/events", headers: headers
 
-      expect(JSON.parse(response.body).map { |i| i["id"] }).to contain_exactly(event3.id,event4.id)
+      actual = JSON.parse(response.body).map { |event| event["id"] }
+
+      expect(actual).to contain_exactly(*audio_events.map(&:id))
     end
 
     xit "lists nothing when asked for events from a video package - pending PFDR-175"
@@ -45,7 +45,10 @@ RSpec.describe "GET /v1/events", :checkpoint_transaction, type: :request do
     it "lists all events" do
       get "/v1/events", headers: headers
 
-      expect(JSON.parse(response.body).map { |i| i["id"] }).to contain_exactly(event1.id,event2.id,event3.id,event4.id)
+      actual = JSON.parse(response.body).map { |event| event["id"] }
+      all_events = audio_events + video_events
+
+      expect(actual).to contain_exactly(*all_events.map(&:id))
     end
   end
 

--- a/spec/requests/v1/packages_file_spec.rb
+++ b/spec/requests/v1/packages_file_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "checkpoint_helper"
 
 RSpec.describe "GET /v1/packages/:bag_id/:file", type: :request do
   let(:key)  { Keycard::DigestKey.new }
   let(:user) { Fabricate(:user, api_key_digest: key.digest) }
   let(:fixture_path) { fixture("video/upload/goodbag") }
-  let(:package) { Fabricate(:package, user: user, storage_location: fixture_path, content_type: 'video') }
+  let(:package) { Fabricate(:package, storage_location: fixture_path, content_type: 'video') }
 
   before(:each) do
     Services.checkpoint.grant!(user,

--- a/spec/requests/v1/packages_index_spec.rb
+++ b/spec/requests/v1/packages_index_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "checkpoint_helper"
+
+RSpec.describe "GET /v1/packages", :checkpoint_transaction, type: :request do
+  let(:key)  { Keycard::DigestKey.new }
+  let!(:user) { Fabricate(:user, api_key_digest: key.digest) }
+
+  let!(:video1) { Fabricate(:package, content_type: 'video') }
+  let!(:video2) { Fabricate(:package, content_type: 'video') }
+  let!(:audio1) { Fabricate(:package, content_type: 'audio') }
+
+  let(:headers) do
+    {  "Authorization"   => "Token token=#{key}" }
+  end
+
+  context "as a video viewer" do
+    # TODO: extract these granting methods from FakeUser?
+    # TODO: allow specifying something more concise in grant!?
+    before(:each) do
+      Services.checkpoint.grant!(user,
+                                 Checkpoint::Credential::Role.new("viewer"),
+                                 Checkpoint::Resource::AllOfType.new("video"))
+    end
+
+    it "lists all video packages & only video packages" do
+      get "/v1/packages", headers: headers
+
+      expect(JSON.parse(response.body).map { |i| i["bag_id"] }).to contain_exactly(video1.bag_id, video2.bag_id)
+    end
+  end
+
+  context "as an admin" do
+    before(:each) do
+      Services.checkpoint.grant!(user,
+                                 Checkpoint::Credential::Role.new('admin'),
+                                 Checkpoint::Resource::AllOfAnyType.new)
+    end
+
+    it "lists all packages" do
+      get "/v1/packages", headers: headers
+
+      expect(JSON.parse(response.body).map { |i| i["bag_id"] }).to contain_exactly(video1.bag_id, video2.bag_id, audio1.bag_id)
+    end
+  end
+
+  context "as a user with no grants" do
+    it "returns a 403" do
+      get "/v1/packages", headers: headers
+
+      expect(response.status).to eq(403)
+    end
+  end
+end

--- a/spec/requests/v1/packages_index_spec.rb
+++ b/spec/requests/v1/packages_index_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe "GET /v1/packages", :checkpoint_transaction, type: :request do
   let(:key)  { Keycard::DigestKey.new }
   let!(:user) { Fabricate(:user, api_key_digest: key.digest) }
 
-  let!(:video1) { Fabricate(:package, content_type: 'video') }
-  let!(:video2) { Fabricate(:package, content_type: 'video') }
-  let!(:audio1) { Fabricate(:package, content_type: 'audio') }
+  let!(:video_packages) { Array.new(2) { Fabricate(:package, content_type: 'video') } }
+  let!(:all_packages) { video_packages + [Fabricate(:package, content_type: 'audio')] }
 
   let(:headers) do
     {  "Authorization"   => "Token token=#{key}" }
@@ -27,7 +26,7 @@ RSpec.describe "GET /v1/packages", :checkpoint_transaction, type: :request do
     it "lists all video packages & only video packages" do
       get "/v1/packages", headers: headers
 
-      expect(JSON.parse(response.body).map { |i| i["bag_id"] }).to contain_exactly(video1.bag_id, video2.bag_id)
+      expect(JSON.parse(response.body).map { |i| i["bag_id"] }).to contain_exactly(*video_packages.map(&:bag_id))
     end
   end
 
@@ -41,7 +40,7 @@ RSpec.describe "GET /v1/packages", :checkpoint_transaction, type: :request do
     it "lists all packages" do
       get "/v1/packages", headers: headers
 
-      expect(JSON.parse(response.body).map { |i| i["bag_id"] }).to contain_exactly(video1.bag_id, video2.bag_id, audio1.bag_id)
+      expect(JSON.parse(response.body).map { |i| i["bag_id"] }).to contain_exactly(*all_packages.map(&:bag_id))
     end
   end
 

--- a/spec/requests/v1/queue_items_index_spec.rb
+++ b/spec/requests/v1/queue_items_index_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "checkpoint_helper"
+
+RSpec.describe "GET /v1/packages", :checkpoint_transaction, type: :request do
+  let(:key)  { Keycard::DigestKey.new }
+  let!(:user) { Fabricate(:user, api_key_digest: key.digest) }
+
+  let!(:video1) { Fabricate(:package, content_type: 'video') }
+  let!(:video2) { Fabricate(:package, content_type: 'video') }
+  let!(:audio1) { Fabricate(:package, content_type: 'audio') }
+
+  let!(:qitem1) { Fabricate(:queue_item, package: video1) }
+  let!(:qitem2) { Fabricate(:queue_item, package: video2) }
+  let!(:qitem3) { Fabricate(:queue_item, package: audio1) }
+
+  let(:headers) do
+    { "Authorization"   => "Token token=#{key}" }
+  end
+
+  context "as a video content manager" do
+    before(:each) do
+      Services.checkpoint.grant!(user,
+                                 Checkpoint::Credential::Role.new("content_manager"),
+                                 Checkpoint::Resource::AllOfType.new("video"))
+    end
+
+    it "lists all video queue items & only video queue items" do
+      get "/v1/queue", headers: headers
+
+      expect(JSON.parse(response.body).map { |i| i["id"] }).to contain_exactly(qitem1.id, qitem2.id)
+    end
+
+    xit "lists nothing when asked for events from an audio package - pending PFDR-175"
+  end
+
+  context "as an admin" do
+    before(:each) do
+      Services.checkpoint.grant!(user,
+                                 Checkpoint::Credential::Role.new('admin'),
+                                 Checkpoint::Resource::AllOfAnyType.new)
+    end
+
+    it "lists all queue items" do
+      get "/v1/queue", headers: headers
+
+      expect(JSON.parse(response.body).map { |i| i["id"] }).to contain_exactly(qitem1.id, qitem2.id, qitem3.id)
+    end
+  end
+
+  context "as a user with no grants" do
+    it "returns a 403" do
+      get "/v1/packages", headers: headers
+
+      expect(response.status).to eq(403)
+    end
+  end
+end

--- a/spec/requests/v1/queue_items_index_spec.rb
+++ b/spec/requests/v1/queue_items_index_spec.rb
@@ -7,13 +7,11 @@ RSpec.describe "GET /v1/packages", :checkpoint_transaction, type: :request do
   let(:key)  { Keycard::DigestKey.new }
   let!(:user) { Fabricate(:user, api_key_digest: key.digest) }
 
-  let!(:video1) { Fabricate(:package, content_type: 'video') }
-  let!(:video2) { Fabricate(:package, content_type: 'video') }
-  let!(:audio1) { Fabricate(:package, content_type: 'audio') }
+  let!(:video_packages) { Array.new(2) { Fabricate(:package, content_type: 'video') } }
+  let!(:audio_package) { Fabricate(:package, content_type: 'audio') }
 
-  let!(:qitem1) { Fabricate(:queue_item, package: video1) }
-  let!(:qitem2) { Fabricate(:queue_item, package: video2) }
-  let!(:qitem3) { Fabricate(:queue_item, package: audio1) }
+  let!(:video_qitems) { video_packages.map { |p| Fabricate(:queue_item, package: p)} }
+  let!(:all_qitems) { video_qitems + [Fabricate(:queue_item, package: audio_package)] }
 
   let(:headers) do
     { "Authorization"   => "Token token=#{key}" }
@@ -29,10 +27,10 @@ RSpec.describe "GET /v1/packages", :checkpoint_transaction, type: :request do
     it "lists all video queue items & only video queue items" do
       get "/v1/queue", headers: headers
 
-      expect(JSON.parse(response.body).map { |i| i["id"] }).to contain_exactly(qitem1.id, qitem2.id)
+      expect(JSON.parse(response.body).map { |i| i["id"] }).to contain_exactly(*video_qitems.map(&:id))
     end
 
-    xit "lists nothing when asked for events from an audio package - pending PFDR-175"
+    xit "lists nothing when asked for queue item from an audio package - pending PFDR-175"
   end
 
   context "as an admin" do
@@ -45,7 +43,7 @@ RSpec.describe "GET /v1/packages", :checkpoint_transaction, type: :request do
     it "lists all queue items" do
       get "/v1/queue", headers: headers
 
-      expect(JSON.parse(response.body).map { |i| i["id"] }).to contain_exactly(qitem1.id, qitem2.id, qitem3.id)
+      expect(JSON.parse(response.body).map { |i| i["id"] }).to contain_exactly(*all_qitems.map(&:id))
     end
   end
 


### PR DESCRIPTION
- there's a fair bit of repetition between these specs and they could
certainly be cleaned up, but we are trying to favor readability over
including a lot of shared contexts etc

- skip specs for attempting to get events or queue item for a package of
an unauthorized type, pending PFDR-175