### PR TITLE
Create docker image with dependencies for integration tests

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,6 +1,8 @@
 SimpleCov.configure do
   add_filter '/.binstubs'
   add_filter '/.bundle/'
+  add_filter '/Dockerfile'
+  add_filter '/docker-compose.yml'
   add_filter '/.git/'
   add_filter '/spec/'
   add_filter '/test/'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+ARG FEED_TAG=jhove-1.6
+FROM hathitrust/feed:${FEED_TAG}
+
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  bison \
+  build-essential \
+  curl \
+  default-libmysqlclient-dev \
+  git \
+  libffi-dev \
+  libgdbm-dev \
+  libncurses5-dev \
+  libreadline-dev \
+  libsqlite3-dev \
+  libssl-dev \
+  libyaml-dev \
+  zlib1g-dev
+
+RUN git clone https://github.com/rbenv/ruby-build.git
+RUN PREFIX=/usr/local ./ruby-build/install.sh
+ARG RUBY_VERSION=2.5.5
+RUN ruby-build -v $RUBY_VERSION /usr/local
+
+RUN gem install bundler
+
+ENV APP_PATH /usr/src/app
+RUN mkdir -p $APP_PATH
+WORKDIR $APP_PATH
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+ENV RUN_INTEGRATION 1
+CMD ["bundle", "exec", "rspec"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.7'
+services:
+  web:
+    build: '.'
+    command: ["/bin/bash"]
+    volumes:
+      - type: bind
+        source: '.'
+        target: '/usr/src/app'
+

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -11,13 +11,18 @@ Development
 Running integration tests
 -------------------------
 
-- Make sure the validation scripts under ``bin`` have all required dependencies
-  installed (out of scope for this respository)
+This repository includes a Docker container that has all of the dependencies of the integration
+tests pre-installed. You will need:
 
-- Set the ``RUN_INTEGRATION`` environment variable; otherwise integration tests
-  are skipped.
+- Docker and Docker Compose
+- The hathitrust/feed:jhove-1.6 and/or the hathitrust/feed:jhove-1.20 images. These can be
+  built from the Dockerfiles in the official
+  `HathiTrust Feed repository <https://github.com/hathitrust/feed/>`_. In the future, they
+  may be uploaded to a public Docker registry.
 
-- Run ``bundle exec rspec``
+Then you can launch the container with ``docker-compose run web bash``, which gives you a shell
+within that container with your current source code mounted. From there, you can install gems
+and run the specs as normal (``bundle install`` and ``bin/rspec``, respectively).
 
 CLI / end-to-end testing
 -----------------------


### PR DESCRIPTION
Resolves PFDR-160
Resolves PFDR-204

Run with `docker-compose run web bash`

I _think_ this all the dependencies working, but that may not be the case. That's difficult to determine until we can get the integration tests passing.