### PR TITLE
Add World modules for users/API requests

### DIFF
--- a/features/step_definitions/deposit_steps.rb
+++ b/features/step_definitions/deposit_steps.rb
@@ -1,27 +1,20 @@
 # frozen_string_literal: true
 
 Given("a preserved Bentley audio artifact") do
-  @artifact ||= Fabricate(:stored_package, content_type: "audio")
+  @artifact = Fabricate(:stored_package, content_type: "audio")
 end
 
 Given("I am a Bentley audio content steward") do
-  @key ||= Keycard::DigestKey.new
-  @user ||= Fabricate(:user, api_key_digest: @key.digest)
-  Services.checkpoint.grant!(
-    @user,
-    Checkpoint::Credential::Role.new('content_manager'),
-    Checkpoint::Resource::AllOfType.new('audio')
-  )
+  make_me_a("content_manager").on_all("audio")
 end
 
 When("I check the status of the artifact") do
-  header("Authorization", "Token token=#{@key}")
-  @bags_response = JSON.parse(get("/v1/bags/#{@artifact.bag_id}").body)
-  @queue_response = JSON.parse(get("/v1/queue?package=#{@artifact.bag_id}").body)
+  api_get("/v1/bags/#{@artifact.bag_id}")
 end
 
 Then("I receive a report that the artifact is preserved") do
-  expect(@bags_response['stored']).to eq true
+  artifact = JSON.parse(last_response.body)
+  expect(artifact['stored']).to eq true
 end
 
 Given("an uploaded but not yet preserved Bentley audio artifact") do

--- a/features/support/world_extensions.rb
+++ b/features/support/world_extensions.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "checkpoint"
+
+class RoleGranter
+  attr_reader :user, :role
+
+  def initialize(user, role, authority: Services.checkpoint)
+    @user = user
+    @role = Checkpoint::Credential::Role.new(role)
+    @authority = authority
+  end
+
+  def on_everything
+    grant! Checkpoint::Resource.all
+  end
+
+  def on_all(type)
+    grant! Checkpoint::Resource::AllOfType.new(type)
+  end
+
+  def on(type, id)
+    grant! Checkpoint::Resource::Token.new(type, id)
+  end
+
+  private
+
+  def grant!(resource)
+    authority.grant!(user, role, resource)
+  end
+
+  attr_reader :authority
+end
+
+module CanManageAccounts
+  def me
+    @me ||= Fabricate(:user, api_key_digest: my_api_key.digest)
+  end
+
+  def make_me_a(role)
+    RoleGranter.new(me, role)
+  end
+
+  def my_api_key
+    @my_api_key ||= Keycard::DigestKey.new
+  end
+
+  alias_method :make_me_an, :make_me_a
+end
+
+module MakesApiRequests
+  def api_get(*args)
+    set_auth_token
+    get(*args)
+  end
+
+  def set_auth_token
+    header("Authorization", "Token token=#{my_api_key}")
+  end
+end
+
+World(CanManageAccounts)
+World(MakesApiRequests)


### PR DESCRIPTION
This adds a couple of prospective conveniences for writing scenarios,
specifically around creating an acting user with a particular role and
making API requests (with the "me" user's API token header).