### PR TITLE
Deposit tests

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -51,7 +51,7 @@ class Package < ApplicationRecord
     elsif format != Chipmunk::Bag.format
       errors << "Package #{bag_id} has invalid format: #{format}"
     elsif !incoming_storage.include?(self)
-      errors << "Bag does not exist at upload location: .../#{user.username}/#{bag_id}"
+      errors << "Bag #{bag_id} does not exist in incoming storage."
     end
 
     return false unless errors.empty?

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -26,7 +26,7 @@ class Package < ApplicationRecord
   end
 
   def upload_link
-    File.join(Rails.application.config.upload["rsync_point"], bag_id)
+    Services.incoming_storage.upload_link(self)
   end
 
   def stored?

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -35,9 +35,15 @@ Services = Canister.new
 # TODO: Separate normal and test contexts
 if Rails.env.test?
   Services.register(:incoming_storage) do
-    Chipmunk::IncomingStorage.new(volume: Chipmunk::Volume.new(
-      name: "incoming", package_type: Chipmunk::Bag, root_path: Chipmunk.config.upload.upload_path
-    ))
+    Chipmunk::IncomingStorage.new(
+      volume: Chipmunk::Volume.new(
+        name: "incoming",
+        package_type: Chipmunk::Bag,
+        root_path: Chipmunk.config.upload.upload_path
+      ),
+      paths: Chipmunk::IncomingStorage::IdPathBuilder.new("/"),
+      links: Chipmunk::IncomingStorage::IdPathBuilder.new(Chipmunk.config.upload["rsync_point"])
+    )
   end
   Services.register(:storage) do
     Chipmunk::PackageStorage.new(volumes: [
@@ -47,9 +53,15 @@ if Rails.env.test?
   end
 else
   Services.register(:incoming_storage) do
-    Chipmunk::IncomingStorage.new(volume: Chipmunk::Volume.new(
-      name: "incoming", package_type: Chipmunk::Bag, root_path: Chipmunk.config.upload.upload_path
-    ))
+    Chipmunk::IncomingStorage.new(
+      volume: Chipmunk::Volume.new(
+        name: "incoming",
+        package_type: Chipmunk::Bag,
+        root_path: Chipmunk.config.upload.upload_path
+      ),
+      paths: Chipmunk::IncomingStorage::UserPathBuilder.new(Chipmunk.config.upload["upload_path"]),
+      links: Chipmunk::IncomingStorage::IdPathBuilder.new(Chipmunk.config.upload["rsync_point"])
+    )
   end
   Services.register(:storage) do
     Chipmunk::PackageStorage.new(volumes: [

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -3,9 +3,11 @@ upload:
   rsync_point: localhost:/tmp/chipmunk/inc
   storage_path: /tmp/chipmunk/store
 validation:
+  # These files noop with exit code 0 under normal test, but delegate to their
+  # corresponding files in bin when RUN_INTEGRATION is 1.
   external:
-    audio: "bin/validate_audio.sh"
-    video: "bin/validate_video.pl"
+    audio: "spec/support/bin/validate_audio.sh"
+    video: "spec/support/bin/validate_video.sh"
   bagger_profile:
     digital: "spec/support/fixtures/test-profile.json"
 checkpoint:

--- a/features/deposit_an_artifact.feature
+++ b/features/deposit_an_artifact.feature
@@ -21,11 +21,7 @@ Feature: Depositing an artifact
     When I upload the bag
     And signal that the artifact is fully uploaded
     Then the deposit of the artifact is acknowledged
-
-  Scenario: Storing an uploaded artifact
-    Given an audio deposit has been completed
-    When processing completes
-    Then the bag is stored in the repository
+    And the bag is stored in the repository
 
   Scenario: A malformed bag is rejected
     Given I have uploaded a malformed bag

--- a/features/deposit_an_artifact.feature
+++ b/features/deposit_an_artifact.feature
@@ -23,8 +23,3 @@ Feature: Depositing an artifact
     Then the deposit of the artifact is acknowledged
     And the bag is stored in the repository
 
-  Scenario: A malformed bag is rejected
-    Given I have uploaded a malformed bag
-    When validation completes
-    Then the bag is not stored in the repository
-    And I can see the reason it failed

--- a/features/reject_an_artifact.feature
+++ b/features/reject_an_artifact.feature
@@ -1,0 +1,14 @@
+Feature: Rejecting a malformed artifact
+  In order to avoid preserving digital artifacts that have no value to me
+  As a content steward
+  I want malformed artifacts to be rejected
+
+  Background:
+    Given I am a Bentley audio content steward
+    And I have a malformed Bentley audio bag to deposit
+
+  Scenario: A malformed bag is rejected
+    Given an audio deposit has been started
+    When I upload the bag
+    And signal that the artifact is fully uploaded
+    Then the bag is not stored in the repository

--- a/features/step_definitions/more_steps.rb
+++ b/features/step_definitions/more_steps.rb
@@ -6,6 +6,10 @@ Given("I have a Bentley audio bag to deposit") do
   @bag = Chipmunk::Bag.new(fixture("test_bag"))
 end
 
+Given("I have a malformed Bentley audio bag to deposit") do
+  @bag = Chipmunk::Bag.new(fixture("bad_test_bag"))
+end
+
 When("I initiate a deposit of an audio bag") do
   api_post(
     "/v1/requests",
@@ -49,16 +53,10 @@ Then("the bag is stored in the repository") do
   expect(Services.storage.for(@package.reload)).to be_valid
 end
 
-Given("I have uploaded a malformed bag") do
-  pending # Write code here that turns the phrase above into concrete actions
-end
-
-When("validation completes") do
-  pending # Write code here that turns the phrase above into concrete actions
-end
-
 Then("the bag is not stored in the repository") do
-  pending # Write code here that turns the phrase above into concrete actions
+  expect {
+    Services.storage.for(@package.reload)
+  }.to raise_error Chipmunk::PackageNotStoredError
 end
 
 Then("I can see the reason it failed") do

--- a/features/step_definitions/more_steps.rb
+++ b/features/step_definitions/more_steps.rb
@@ -45,16 +45,8 @@ Then("the deposit of the artifact is acknowledged") do
   expect(api_get(last_response['Location']).status).to eql(200)
 end
 
-Given("an audio deposit has been completed") do
-  pending # Write code here that turns the phrase above into concrete actions
-end
-
-When("processing completes") do
-  pending # Write code here that turns the phrase above into concrete actions
-end
-
 Then("the bag is stored in the repository") do
-  pending # Write code here that turns the phrase above into concrete actions
+  expect(Services.storage.for(@package.reload)).to be_valid
 end
 
 Given("I have uploaded a malformed bag") do

--- a/lib/chipmunk/incoming_storage.rb
+++ b/lib/chipmunk/incoming_storage.rb
@@ -1,12 +1,46 @@
 # frozen_string_literal: true
 
+require "pathname"
+
 module Chipmunk
   # IncomingStorage is a factory for proxies to storage of incoming deposits.
   class IncomingStorage
 
+    class UserPathBuilder
+      def initialize(root_path)
+        @root_path = Pathname.new(root_path)
+        raise ArgumentError, "root_path must not be nil" unless @root_path
+      end
+
+      def for(package)
+        File.join(root_path, package.user.username, package.bag_id)
+      end
+
+      private
+
+      attr_reader :root_path
+    end
+
+    class IdPathBuilder
+      def initialize(root_path)
+        @root_path = Pathname.new(root_path)
+        raise ArgumentError, "root_path must not be nil" unless @root_path
+      end
+
+      def for(package)
+        File.join(root_path, package.bag_id)
+      end
+
+      private
+
+      attr_reader :root_path
+    end
+
     # Create an IncomingStorage instance.
-    def initialize(volume:)
+    def initialize(volume:, paths:, links: )
       @volume = volume
+      @paths = paths
+      @links = links
     end
 
     def for(package)
@@ -20,15 +54,15 @@ module Chipmunk
     end
 
     def upload_link(package)
-      File.join(Rails.application.config.upload["rsync_point"], package.bag_id)
+      links.for(package)
     end
 
     private
 
     def upload_path(package)
-      File.join("/", package.user.username, package.bag_id)
+      paths.for(package)
     end
 
-    attr_reader :volume
+    attr_reader :volume, :paths, :links
   end
 end

--- a/lib/chipmunk/incoming_storage.rb
+++ b/lib/chipmunk/incoming_storage.rb
@@ -3,7 +3,9 @@
 require "pathname"
 
 module Chipmunk
-  # IncomingStorage is a factory for proxies to storage of incoming deposits.
+  # IncomingStorage is responsible for the business rules of writing to and reading from
+  # Volumes earmarked for its use. It is specifically concerned with initial upload of bags,
+  # and makes them available to other parts of the system via its methods.
   class IncomingStorage
 
     class UserPathBuilder
@@ -37,6 +39,11 @@ module Chipmunk
     end
 
     # Create an IncomingStorage instance.
+    # @param volume [Volume] The Volume from which the deposited packages should be ingested
+    # @param paths [PathBuilder] A PathBuilder that returns a path on disk to the user upload
+    #   location for a deposit, for a given package.
+    # @param links [PathBuilder] A PathBuilder that returns an rsync destination to which the
+    #   user should upload, for a given package.
     def initialize(volume:, paths:, links: )
       @volume = volume
       @paths = paths

--- a/lib/chipmunk/incoming_storage.rb
+++ b/lib/chipmunk/incoming_storage.rb
@@ -19,6 +19,10 @@ module Chipmunk
       volume.include?(upload_path(package))
     end
 
+    def upload_link(package)
+      File.join(Rails.application.config.upload["rsync_point"], package.bag_id)
+    end
+
     private
 
     def upload_path(package)

--- a/lib/chipmunk/package_storage.rb
+++ b/lib/chipmunk/package_storage.rb
@@ -47,9 +47,7 @@ module Chipmunk
       FileUtils.mkdir_p(dest_path)
       File.rename(source.path, dest_path)
 
-      package.storage_volume = volume.name
-      package.storage_path = storage_path
-      true
+      package.update(storage_volume: volume.name, storage_path: storage_path)
     end
 
     # We are defaulting everything to "bags" for now as the simplest resolution strategy.

--- a/spec/all_support.rb
+++ b/spec/all_support.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 support_dir = File.expand_path(File.join(__dir__, "support"))
-[".", "examples", "contexts", "helpers"].each do |folder|
+
+Dir[File.join(support_dir, "*.rb")].each {|f| require f }
+
+["examples", "contexts", "helpers"].each do |folder|
   Dir[File.join(support_dir, folder, "**", "*.rb")].each {|f| require f }
 end

--- a/spec/chipmunk/incoming_storage_spec.rb
+++ b/spec/chipmunk/incoming_storage_spec.rb
@@ -1,14 +1,28 @@
 # frozen_string_literal: true
 
 RSpec.describe Chipmunk::IncomingStorage do
-  subject(:storage) { described_class.new(volume: volume) }
+  subject(:storage) { described_class.new(volume: volume, paths: path_builder, links: path_builder) }
+  subject(:storage) do
+    described_class.new(
+      volume: volume,
+      paths: described_class::UserPathBuilder.new("/"),
+      links: described_class::IdPathBuilder.new("rsync:foo")
+    )
+  end
 
   let(:package_type) { double("SomePackageFormat", format: "some-pkg") }
   let(:volume) { Chipmunk::Volume.new(name: "incoming", package_type: package_type, root_path: "/incoming") }
+  let(:path_builder) { Chipmunk::IncomingStorage::IdPathBuilder.new("/") }
 
   let(:uploader)         { instance_double("User", username: "uploader") }
   let(:unstored_package) { instance_double("Package", stored?: false, user: uploader, bag_id: "abcdef-123456") }
   let(:stored_package)   { instance_double("Package", stored?: true) }
+
+  describe "#upload_link" do
+    it "reports the upload link" do
+      expect(storage.upload_link(unstored_package)).to eql("rsync:foo/#{unstored_package.bag_id}")
+    end
+  end
 
   context "with a package that is already in preservation" do
     it "raises an already-stored error" do

--- a/spec/chipmunk/package_storage_spec.rb
+++ b/spec/chipmunk/package_storage_spec.rb
@@ -90,12 +90,13 @@ RSpec.describe Chipmunk::PackageStorage do
       end
 
       it "sets the storage_volume" do
-        expect(package).to receive(:storage_volume=).with("bags")
+        expect(package).to receive(:update).with(a_hash_including(storage_volume: "bags"))
         storage.write(package, disk_bag)
       end
 
       it "sets the storage_path with three levels of hierarchy" do
-        expect(package).to receive(:storage_path=).with("/ab/cd/ef/abcdef-123456")
+        expect(package).to receive(:update)
+          .with(a_hash_including(storage_path: "/ab/cd/ef/abcdef-123456"))
         storage.write(package, disk_bag)
       end
     end

--- a/spec/features/end_to_end.feature
+++ b/spec/features/end_to_end.feature
@@ -14,7 +14,7 @@ Feature: End to End functionality
     And validation.external.audio is "true"
 
   Scenario Outline: Create initial request and verify
-    Given "/tmp/chipmunk/inc/<username>" exists and is empty
+    Given "/tmp/chipmunk/inc" exists and is empty
     And "/tmp/chipmunk/store" exists and is empty
 
     When I send a POST request to "/v1/requests" with this json:
@@ -37,7 +37,7 @@ Feature: End to End functionality
       | created_at    | 2017-05-17 18:49:08 UTC              |
       | updated_at    | 2017-05-17 18:49:08 UTC              |
     # simulates action of correctly-configured rsync (out of scope of the application)
-    When I copy a test bag to "/tmp/chipmunk/inc/<username>/<bag_id>"
+    When I copy a test bag to "/tmp/chipmunk/inc/<bag_id>"
     Then copy finishes successfully
     When I send an empty POST request to "/v1/requests/<bag_id>/complete"
     Then the response status should be "201"

--- a/spec/integration/audio_spec.rb
+++ b/spec/integration/audio_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe "audio validation integration", integration: true do
   it_behaves_like "a validation integration" do
     let(:content_type) { "audio" }
     let(:external_id) { "39015087086396" }
-    let(:validation_script) { "validate_audio.sh" }
     let(:expected_error) { /ERROR - Missing file.*file: pm000001.wav/m }
   end
 end

--- a/spec/integration/video_spec.rb
+++ b/spec/integration/video_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe "video validation integration", integration: true do
   it_behaves_like "a validation integration" do
     let(:content_type) { "video" }
     let(:external_id) { "39015083611155" }
-    let(:validation_script) { "validate_video.pl" }
     let(:expected_error) { /Error validating.*Unexpected files/m }
   end
 end

--- a/spec/support/bin/validate_audio.sh
+++ b/spec/support/bin/validate_audio.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ "$RUN_INTEGRATION" == "1" ]; then
+  exec bin/validate_audio.sh "$@"
+else
+  exit 0
+fi

--- a/spec/support/bin/validate_video.sh
+++ b/spec/support/bin/validate_video.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ "$RUN_INTEGRATION" == "1" ]; then
+  exec bin/validate_video.pl "$@"
+else
+  exit 0
+fi

--- a/spec/support/examples/a_validation_integration.rb
+++ b/spec/support/examples/a_validation_integration.rb
@@ -9,8 +9,6 @@ require "fileutils"
 #   under spec/support/fixtures/content_type/{good,bad}
 # @param external_id [String] The external identifier that should be used when
 #   constructing Bags.
-# @param validation_script [String] The validation command to run - should be an
-#   executable script under bin
 # @param expected_error [Regexp] A Regexp that the expected output from
 #   validating spec/support/fixtures/content_type/bad should match.
 RSpec.shared_examples "a validation integration" do
@@ -18,28 +16,23 @@ RSpec.shared_examples "a validation integration" do
     File.join(Rails.application.root, "spec", "support", "fixtures", *args)
   end
 
-  before(:each) do
-    @old_validation = Rails.application.config.validation[content_type]
-    @old_upload_path = Rails.application.config.upload["upload_path"]
-    Rails.application.config.validation["external"][content_type] = File.join(Rails.application.root, "bin", validation_script)
-
-    @old_incoming_storage = Services.incoming_storage
-
+  around(:each) do |example|
+    old_incoming_storage = Services.incoming_storage
     Services.register(:incoming_storage) do
-      Chipmunk::IncomingStorage.new(volume: Chipmunk::Volume.new(
-        name: "incoming", package_type: Chipmunk::Bag, root_path: fixture(content_type)
-      ))
+      Chipmunk::IncomingStorage.new(
+        volume: Chipmunk::Volume.new(name: "incoming", package_type: Chipmunk::Bag, root_path: fixture(content_type)),
+        paths: Chipmunk::IncomingStorage::UserPathBuilder.new("/"),
+        links: Chipmunk::IncomingStorage::IdPathBuilder.new("/this/does/not/get/used")
+      )
     end
 
-    allow(Services.storage).to receive(:write).with(package, anything).and_return true
+    example.run
+
+    Services.register(:incoming_storage) { old_incoming_storage}
   end
 
-  after(:each) do
-    Rails.application.config.validation["external"][content_type] = @old_validation
-
-    Services.register(:incoming_storage) do
-      @old_incoming_storage
-    end
+  before(:each) do
+    allow(Services.storage).to receive(:write).with(package, anything).and_return true
   end
 
   # for known upload location under fixtures/video

--- a/spec/support/fixtures/bad_test_bag/bag-info.txt
+++ b/spec/support/fixtures/bad_test_bag/bag-info.txt
@@ -1,0 +1,3 @@
+Bag-Software-Agent: BagIt Ruby Gem (http://bagit.rubyforge.org)
+Bagging-Date: 2017-06-19
+Payload-Oxum: 11.1

--- a/spec/support/fixtures/bad_test_bag/bagit.txt
+++ b/spec/support/fixtures/bad_test_bag/bagit.txt
@@ -1,0 +1,2 @@
+BagIt-Version: 0.97
+Tag-File-Character-Encoding: UTF-8

--- a/spec/support/fixtures/bad_test_bag/chipmunk-info.txt
+++ b/spec/support/fixtures/bad_test_bag/chipmunk-info.txt
@@ -1,0 +1,3 @@
+External-Identifier: test_ex_id_22
+Chipmunk-Content-Type: audio
+Bag-ID: 14d25bcd-deaf-4c94-add7-c189fdca4692

--- a/spec/support/fixtures/bad_test_bag/data/samplefile
+++ b/spec/support/fixtures/bad_test_bag/data/samplefile
@@ -1,0 +1,1 @@
+Hello Bag!

--- a/spec/support/fixtures/bad_test_bag/manifest-md5.txt
+++ b/spec/support/fixtures/bad_test_bag/manifest-md5.txt
@@ -1,0 +1,1 @@
+71da23dbd1935f78b24c790c47992691 data/samplefile

--- a/spec/support/fixtures/bad_test_bag/manifest-sha1.txt
+++ b/spec/support/fixtures/bad_test_bag/manifest-sha1.txt
@@ -1,0 +1,1 @@
+6570a827884d8936ea2f8b084705c24aa6f9d7ee data/samplefile

--- a/spec/support/fixtures/bad_test_bag/tagmanifest-md5.txt
+++ b/spec/support/fixtures/bad_test_bag/tagmanifest-md5.txt
@@ -1,0 +1,6 @@
+22340b9567d070bf6022b85e68948727  bag-info.txt
+9e5ad981e0d29adc278f6a294b8c2aca  bagit.txt
+b6483e6c6ce33037e6e7cea79d3fde3f  chipmunk-info.txt
+a7a2803e003c74159725db55d91a5981  manifest-md5.txt
+c5f316f266735235e4c62c88983ac711  manifest-sha1.txt
+d41d8cd98f00b204e9800998ecf8427e  meta.xml

--- a/spec/support/fixtures/bad_test_bag/tagmanifest-sha1.txt
+++ b/spec/support/fixtures/bad_test_bag/tagmanifest-sha1.txt
@@ -1,0 +1,6 @@
+e29dcf1ce489cb9fe75631a16918c1206330f01b  bag-info.txt
+e2924b081506bac23f5fffe650ad1848a1c8ac1d  bagit.txt
+de9f9cc575445fd0b722198783d25ab7b5c7d3f9  chipmunk-info.txt
+ea0b21f9502fc9155bc065faaab275fe9dfd637f  manifest-md5.txt
+0f1e283905e1e0c5082ce6b9dd34e8c3d589b9ce  manifest-sha1.txt
+da39a3ee5e6b4b0d3255bfef95601890afd80709  meta.xml


### PR DESCRIPTION
This wraps up the depositing and upload features. The primary difficulty stemmed from the mismatch between the upload_link and the upload_path; the logic was assumed production's environment, so performing pseudo-uploads in the acceptance tests was next to impossible.

The primary approach I took was to move the upload_link responsibility to IncomingStorage via dependency injection, thereby allowing for the same behavior to achieve both production's needs and our tests. No changes are required in prod, and the tests that exercised that behavior are still in place.

Each commit is pursuant the above goals and strategy. 

