### PR TITLE
Update yard for security alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,7 +294,7 @@ GEM
     websocket-extensions (0.1.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.19)
+    yard (0.9.20)
     zip_tricks (4.7.2)
 
 PLATFORMS


### PR DESCRIPTION
The security alert basically requires one to be running a yard server, which literally only rubodoc.info does, but the alert is annoying and it's good practice to stay on top of these.