### PR TITLE
Update bundler 2.0.1 -> 2.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,4 +336,4 @@ DEPENDENCIES
   zip_tricks
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
They call it a minor version update but the thing completely breaks if you're not on the exact same version. We have 2.0.2 on servers so this is basically required.