### PR TITLE
PFDR-231 - Use relative paths for incoming packages

### DIFF
--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -59,7 +59,7 @@ else
         package_type: Chipmunk::Bag,
         root_path: Chipmunk.config.upload.upload_path
       ),
-      paths: Chipmunk::UserUploadPath.new(Chipmunk.config.upload["upload_path"]),
+      paths: Chipmunk::UserUploadPath.new("/"),
       links: Chipmunk::UploadPath.new(Chipmunk.config.upload["rsync_point"])
     )
   end


### PR DESCRIPTION
This is the minimal fix for the problem of no incoming uploads resolving. It does not treat the peculiarity that the argument is called root_path, nor the inconsistency between UploadPath (which works on paths directly) and UserUploadPath (which only works within the incoming storage volume)... but it does what we need.