### PR TITLE
Update nio4r to 2.5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
     mustermann (1.0.2)
     mysql2 (0.4.10)
     netrc (0.11.0)
-    nio4r (2.3.1)
+    nio4r (2.5.1)
     nokogiri (1.10.1)
       mini_portile2 (~> 2.4.0)
     parallel (1.17.0)


### PR DESCRIPTION
This is a workaround for the system puma dependency mismatch issue. You'll need to redeploy the application from deployhost after merging.