### PR TITLE
PFDR-265 - Add validate_bentleyaudio

### DIFF
--- a/bin/validate_bentleyaudio.sh
+++ b/bin/validate_bentleyaudio.sh
@@ -11,4 +11,4 @@ export HTFEED_CONFIG=$FEED_HOME/etc/config_audio.yaml
 
 EXTERNAL_ID=$1
 BAG_DIRECTORY=$2
-perl $FEED_HOME/bin/validate_vendoraudio_chipmunk.pl "$EXTERNAL_ID" "$BAG_DIRECTORY/data" -level INFO -file - 1>&2
+perl $FEED_HOME/bin/validate_bentleyaudio_chipmunk.pl "$EXTERNAL_ID" "$BAG_DIRECTORY/data" -level INFO -file - 1>&2

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -10,6 +10,7 @@ upload:
 validation:
   external:
     audio: "bin/validate_audio.sh"
+    bentleyaudio: "bin/validate_bentleyaudio.sh"
     video: "bin/validate_video.pl"
   bagger_profile:
     digital: "http://uri_to_bagger_profile"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -9,6 +9,7 @@ validation:
   # corresponding files in bin when RUN_INTEGRATION is 1.
   external:
     audio: "spec/support/bin/validate_audio.sh"
+    bentleyaudio: "spec/support/bin/validate_bentleyaudio.sh"
     video: "spec/support/bin/validate_video.sh"
   bagger_profile:
     digital: "spec/support/fixtures/test-profile.json"

--- a/config/validation.yml
+++ b/config/validation.yml
@@ -2,6 +2,7 @@
 
 external:
   audio: <%= Chipmunk.config.validation.external.audio %>
+  bentleyaudio: <%= Chipmunk.config.validation.external.bentleyaudio %>
   video: <%= Chipmunk.config.validation.external.video %>
 bagger_profile:
   digital: <%= Chipmunk.config.validation.bagger_profile.digital %>

--- a/spec/support/bin/validate_bentleyaudio.sh
+++ b/spec/support/bin/validate_bentleyaudio.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ "$RUN_INTEGRATION" == "1" ]; then
+  exec bin/validate_bentleyaudio.sh "$@"
+else
+  exit 0
+fi


### PR DESCRIPTION
With the separate content type, it's easiest to have a separate driver
script for validation. We could extract pieces or do parameter parsing,
but I want to leave that for when we consider if there are variants of
content types or not. For now, it is only apparent duplication.