### PR TITLE
PFDR-277 - Add rake task to restart lost jobs

### DIFF
--- a/lib/tasks/restart_jobs.rake
+++ b/lib/tasks/restart_jobs.rake
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+task restart_jobs: :environment do
+  jobs = Resque.size "default"
+  working = Resque.working
+  pending = QueueItem.pending
+  should_run = (jobs.zero? && working.count.zero? && pending.count.positive?)
+  message = "Active workers or no pending jobs; will not start any."
+  message = "Pending jobs and idle queue; will attempt to restart." if should_run
+
+  Rails.logger.info <<~BLOCKMSG
+    Scanning for lost ingest jobs...
+        Jobs in default queue: #{jobs}
+        Workers active: #{working.count}
+        QueueItems pending: #{pending.count}
+    #{message}
+  BLOCKMSG
+
+  if should_run
+    qi = pending.first
+    Rails.logger.info "Restarting apparent lost job: QI: #{qi.id}, P: #{qi.package.id}, EID: #{qi.package.external_id}"
+    BagMoveJob.perform_later(qi)
+  end
+end


### PR DESCRIPTION
We've seen Resque jobs crash occasionally, which leaves QueueItems in
pending status but with nothing in the queue, so they are permanently
orphaned. It's apparently because of some strange threading deadlock
with semantic_logger. Those we have enqueued again have finished.

This rake task is intentionally naive. It checks for pending jobs and
the queue. If there are no jobs running but any are marked pending, they
are considered stranded and the oldest is put back into the queue.